### PR TITLE
Ensure editor can be opened in code and moved around

### DIFF
--- a/src/editor-provider.ts
+++ b/src/editor-provider.ts
@@ -29,9 +29,12 @@ export class YamlEditorProvider implements vscode.CustomTextEditorProvider {
         });
 
         const provider = new YamlEditorProvider(context);
+        // use 'retainContextWhenHidden' as other persistence option (i.e., getState/setState) did not work
+        // see https://code.visualstudio.com/api/extension-guides/webview#persistence for more context
         const providerRegistration = vscode.window.registerCustomEditorProvider(
             YamlEditorProvider.viewType,
-            provider
+            provider,
+            { webviewOptions: { retainContextWhenHidden: true } }
         );
         return providerRegistration;
     }
@@ -78,10 +81,6 @@ export class YamlEditorProvider implements vscode.CustomTextEditorProvider {
             switch (e.type) {
                 case 'updateDocument':
                     this.updateYamlDocument(document, e.text);
-                    webviewPanel.webview.postMessage({
-                        type: 'update',
-                        text: e.text
-                    });
                     break;
             }
         });

--- a/webview-react-ui/src/yaml-table.tsx
+++ b/webview-react-ui/src/yaml-table.tsx
@@ -136,7 +136,6 @@ export default function YAMLVariablesTable(props: YAMLVariablesTableProps) {
                 variableKey
             ];
             props.vscodeApi.postMessage({ type: 'updateDocument', text: YAML.stringify(tmpYaml) });
-            setYaml(tmpYaml);
         }
     }
 
@@ -201,6 +200,5 @@ export default function YAMLVariablesTable(props: YAMLVariablesTableProps) {
             type: 'updateDocument',
             text: YAML.stringify(newYamlDocument)
         });
-        setYaml(newYamlDocument);
     }
 }


### PR DESCRIPTION
- Avoid unnecessary update cycles
- Retain context when hidden to keep state persisted