### PR TITLE
Only clean ws on success

### DIFF
--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -49,7 +49,7 @@ pipeline {
   }
 
   post {
-    always {
+    success {
       cleanWs()
     }
   }


### PR DESCRIPTION
So it is easier to find out what was wrong if the build fails or is unstable