### PR TITLE
XIVY-11980 implement fileMetadata

### DIFF
--- a/packages/new-editor/src/components/variables/data/variable.test.ts
+++ b/packages/new-editor/src/components/variables/data/variable.test.ts
@@ -1,4 +1,12 @@
-import { isEnumMetadata, metadataOptions, toEnumMetadataUpdate, variableMetadataAttribute } from './variable';
+import {
+  fileMetadataFilenameExtensionOptions,
+  isEnumMetadata,
+  isFileMetadata,
+  metadataOptions,
+  toEnumMetadataUpdate,
+  toFileMetadataUpdate,
+  variableMetadataAttribute
+} from './variable';
 
 describe('variable', () => {
   describe('metadataOptions', () => {
@@ -29,5 +37,36 @@ describe('variable', () => {
   test('toEnumMetadataUpdate', () => {
     const values = ['value0', 'value1'];
     expect(toEnumMetadataUpdate(values)).toEqual({ key: variableMetadataAttribute, value: { type: 'enum', values: values } });
+  });
+
+  describe('fileMetadataFilenameExtensionOptions', () => {
+    test('allOptionsPresent', () => {
+      expect(fileMetadataFilenameExtensionOptions).toEqual([
+        { label: 'txt', value: 'txt' },
+        { label: 'json', value: 'json' }
+      ]);
+    });
+  });
+
+  describe('isFileMetadata', () => {
+    test('default', () => {
+      expect(isFileMetadata({ type: 'file' })).toBeTruthy();
+    });
+
+    test('isNotFileMetadata', () => {
+      expect(isFileMetadata({ type: 'password' })).toBeFalsy();
+    });
+
+    test('metadataNotProvided', () => {
+      expect(isFileMetadata()).toBeFalsy();
+    });
+  });
+
+  test('toFileMetadataUpdate', () => {
+    const filenameExtension = 'txt';
+    expect(toFileMetadataUpdate(filenameExtension)).toEqual({
+      key: variableMetadataAttribute,
+      value: { type: 'file', filenameExtension: filenameExtension }
+    });
   });
 });

--- a/packages/new-editor/src/components/variables/data/variable.ts
+++ b/packages/new-editor/src/components/variables/data/variable.ts
@@ -19,8 +19,19 @@ export const metadataOptions = [
 
 export type MetadataType = (typeof metadataOptions)[number]['value'] | '';
 export type Metadata = { type: MetadataType };
+
 export interface EnumMetadata extends Metadata {
   values: Array<string>;
+}
+
+export const fileMetadataFilenameExtensionOptions = [
+  { label: 'txt', value: 'txt' },
+  { label: 'json', value: 'json' }
+] as const satisfies Array<{ label: string; value: string }>;
+
+export type FileMetadataFilenameExtension = (typeof fileMetadataFilenameExtensionOptions)[number]['value'];
+export interface FileMetadata extends Metadata {
+  filenameExtension: FileMetadataFilenameExtension;
 }
 
 export const isEnumMetadata = (metadata?: Metadata): metadata is EnumMetadata => {
@@ -28,5 +39,13 @@ export const isEnumMetadata = (metadata?: Metadata): metadata is EnumMetadata =>
 };
 export const toEnumMetadataUpdate = (values: Array<string>): VariableUpdate => {
   const metadata: EnumMetadata = { type: 'enum', values: values };
+  return { key: variableMetadataAttribute, value: metadata };
+};
+
+export const isFileMetadata = (metadata?: Metadata): metadata is FileMetadata => {
+  return metadata !== undefined && metadata.type === 'file';
+};
+export const toFileMetadataUpdate = (filenameExtension: FileMetadataFilenameExtension): VariableUpdate => {
+  const metadata: FileMetadata = { type: 'file', filenameExtension: filenameExtension };
   return { key: variableMetadataAttribute, value: metadata };
 };

--- a/packages/new-editor/src/components/variables/detail/Metadata.tsx
+++ b/packages/new-editor/src/components/variables/detail/Metadata.tsx
@@ -1,9 +1,13 @@
 import { Fieldset, SimpleSelect } from '@axonivy/ui-components';
 import { treeNodeValueAttribute } from '../../../utils/tree/types';
 import {
+  fileMetadataFilenameExtensionOptions,
   isEnumMetadata,
+  isFileMetadata,
   metadataOptions,
+  toFileMetadataUpdate,
   variableMetadataAttribute,
+  type FileMetadataFilenameExtension,
   type MetadataType,
   type Variable,
   type VariableUpdates
@@ -31,6 +35,10 @@ export const Metadata = ({ variable, onChange }: MetadataFieldsetProps) => {
           newMetadata.values = [''];
         }
         break;
+      case 'file':
+        if (isFileMetadata(newMetadata)) {
+          newMetadata.filenameExtension = 'txt';
+        }
     }
     updates.push({ key: variableMetadataAttribute, value: newMetadata });
     onChange(updates);
@@ -42,6 +50,15 @@ export const Metadata = ({ variable, onChange }: MetadataFieldsetProps) => {
         <SimpleSelect value={metadata.type} items={metadataOptions} emptyItem={true} onValueChange={onValueChange} />
       </Fieldset>
       {isEnumMetadata(metadata) && <EnumValues selectedValue={variable.value} values={metadata.values} onChange={onChange} />}
+      {isFileMetadata(metadata) && (
+        <Fieldset label='Filename extension'>
+          <SimpleSelect
+            value={metadata.filenameExtension}
+            items={fileMetadataFilenameExtensionOptions}
+            onValueChange={(filenameExtension: FileMetadataFilenameExtension) => onChange([toFileMetadataUpdate(filenameExtension)])}
+          />
+        </Fieldset>
+      )}
     </>
   );
 };


### PR DESCRIPTION
I think this is fine for now but would it make sense to change the value input to a file picker in the future?
I guess this is not so straight-forward to implement.

![file-metadata](https://github.com/axonivy/config-editor-client/assets/141232142/e01429fd-762f-4ec2-a22d-9671a68726af)
