### PR TITLE
XIVY-14079 focus name input of new variable

### DIFF
--- a/packages/variable-editor/src/components/variables/detail/VariablesDetail.tsx
+++ b/packages/variable-editor/src/components/variables/detail/VariablesDetail.tsx
@@ -30,6 +30,7 @@ export const VariablesDetail = ({ variables, variablePath, setVariables }: Varia
         <Input
           value={variable.name}
           onChange={event => handleVariableAttributeChange([{ key: treeNodeNameAttribute, value: event.target.value }])}
+          autoFocus={variable.name.length === 0}
         />
       </Fieldset>
       {!hasChildren && <Value variable={variable} onChange={handleVariableAttributeChange} />}


### PR DESCRIPTION
Not sure why but this actually does work and really only takes focus after adding a new variable.

![focus-name-input](https://github.com/axonivy/config-editor-client/assets/141232142/5c6bc3f8-8e0c-4bb0-b8e3-c56975ce4ea2)
