### PR TITLE
fix console warning

### DIFF
--- a/packages/variable-editor/src/VariableEditor.tsx
+++ b/packages/variable-editor/src/VariableEditor.tsx
@@ -41,7 +41,9 @@ function VariableEditor(props: DataContext) {
   useQuery({
     queryKey: queryKeys.validate(),
     queryFn: async () => {
-      setValidationMessages(await client.validate(context));
+      const validationMessages = await client.validate(context);
+      setValidationMessages(validationMessages);
+      return validationMessages;
     }
   });
 


### PR DESCRIPTION
"Query data cannot be undefined. Please make sure to return a value other than undefined from your query function. Affected query key: ["validate"]"