### PR TITLE
XIVY-14003 remove scrollbar if validation messages are present

### DIFF
--- a/packages/variable-editor/src/components/variables/master/VariablesMaster.css
+++ b/packages/variable-editor/src/components/variables/master/VariablesMaster.css
@@ -1,0 +1,3 @@
+.ui-table-root {
+  overflow: hidden scroll;
+}

--- a/packages/variable-editor/src/components/variables/master/VariablesMaster.tsx
+++ b/packages/variable-editor/src/components/variables/master/VariablesMaster.tsx
@@ -21,6 +21,7 @@ import { validationMessagesOfRow } from '../data/validation-utils';
 import { type Variable } from '../data/variable';
 import { variableIcon } from '../data/variable-utils';
 import { ValidationRow } from './ValidationRow';
+import './VariablesMaster.css';
 
 type VariablesProps = {
   variables: Array<Variable>;


### PR DESCRIPTION
When validation messages are present, a horizontal scrollbar appears at the bottom of the table because of the border around the table row. I tried many different approaches like `box-sizing: border-box` and calculating a new width if validation messages are present (`width: calc(100% - 2px)`) but nothing worked. This is the approach I landed on.

Before:
![image](https://github.com/axonivy/config-editor-client/assets/141232142/b28eba95-2850-4579-a266-02260f3bb048)


After:
![image](https://github.com/axonivy/config-editor-client/assets/141232142/9ceae87c-a048-4b1b-a838-85c31daee614)
