### PR TITLE
XIVY-14357 fill namespace on add dialog open

### DIFF
--- a/integrations/standalone/tests/mock/variable-editor.spec.ts
+++ b/integrations/standalone/tests/mock/variable-editor.spec.ts
@@ -1,6 +1,6 @@
+import { test } from '@playwright/test';
 import type { Table } from '../pageobjects/Table';
 import { VariableEditor } from '../pageobjects/VariableEditor';
-import { test } from '@playwright/test';
 
 test.describe('VariableEditor', () => {
   let editor: VariableEditor;
@@ -9,6 +9,7 @@ test.describe('VariableEditor', () => {
   test.beforeEach(async ({ page }) => {
     editor = await VariableEditor.openMock(page);
     tree = editor.tree;
+    await tree.expectRowCount(11);
   });
 
   test('title', async () => {
@@ -17,7 +18,6 @@ test.describe('VariableEditor', () => {
 
   test('search', async () => {
     const search = editor.search;
-    await tree.expectRowCount(11);
 
     await search.fill('Hello');
     await search.expectValue('Hello');
@@ -34,8 +34,6 @@ test.describe('VariableEditor', () => {
   });
 
   test('delete', async () => {
-    await tree.expectRowCount(11);
-
     const row = tree.row(6);
     await row.click();
     await row.expectValues(['enabled', 'false']);
@@ -49,8 +47,6 @@ test.describe('VariableEditor', () => {
   });
 
   test('delete last child', async () => {
-    await tree.expectRowCount(11);
-
     const row = tree.row(8);
     await row.click();
     await row.expectValues(['pass', '***']);
@@ -67,8 +63,6 @@ test.describe('VariableEditor', () => {
   });
 
   test('delete last remaining child', async () => {
-    await tree.expectRowCount(11);
-
     const row = tree.row(6);
     await row.click();
     await editor.delete.click();
@@ -86,16 +80,20 @@ test.describe('VariableEditor', () => {
   });
 
   test('add', async () => {
-    await tree.expectRowCount(11);
-
     await tree.row(5).click();
     await tree.row(5).expectValues(['useUserPassFlow', '']);
     await editor.addVariable();
     await tree.expectRowCount(12);
   });
 
+  test('addVariableDialogDefaultValues', async () => {
+    await tree.row(5).click();
+    await tree.row(5).expectValues(['useUserPassFlow', '']);
+    await editor.add.open();
+    await editor.add.expectValues('', 'microsoft-connector.useUserPassFlow');
+  });
+
   test('collapse', async () => {
-    await tree.expectRowCount(11);
     const row = tree.row(5);
     await row.expectExpanded();
     await row.collapse();

--- a/integrations/standalone/tests/pageobjects/AddVariableDialog.ts
+++ b/integrations/standalone/tests/pageobjects/AddVariableDialog.ts
@@ -1,0 +1,31 @@
+import type { Locator, Page } from '@playwright/test';
+import { Button } from './Button';
+import { Combobox } from './Combobox';
+import { TextArea } from './TextArea';
+
+export class AddVariableDialog {
+  private readonly add: Button;
+  private readonly name: TextArea;
+  private readonly namespace: Combobox;
+  private readonly create: Button;
+
+  constructor(page: Page, parent: Locator) {
+    this.add = new Button(parent, { name: 'Add variable' });
+    this.name = new TextArea(parent);
+    this.namespace = new Combobox(page, parent);
+    this.create = new Button(parent, { name: 'Create variable' });
+  }
+
+  async open() {
+    await this.add.click();
+  }
+
+  async expectValues(name: string, namespace: string) {
+    await this.name.expectValue(name);
+    await this.namespace.expectValue(namespace);
+  }
+
+  async createVariable() {
+    await this.create.click();
+  }
+}

--- a/integrations/standalone/tests/pageobjects/Combobox.ts
+++ b/integrations/standalone/tests/pageobjects/Combobox.ts
@@ -1,0 +1,18 @@
+import type { Locator, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+export class Combobox {
+  readonly locator: Locator;
+
+  constructor(readonly page: Page, parentLocator: Locator, options?: { label?: string; nth?: number }) {
+    if (options?.label) {
+      this.locator = parentLocator.getByRole('combobox', { name: options.label }).first();
+    } else {
+      this.locator = parentLocator.getByRole('combobox').nth(options?.nth ?? 0);
+    }
+  }
+
+  async expectValue(value: string | RegExp) {
+    await expect(this.locator).toHaveValue(value);
+  }
+}

--- a/integrations/standalone/tests/pageobjects/VariableEditor.ts
+++ b/integrations/standalone/tests/pageobjects/VariableEditor.ts
@@ -1,16 +1,17 @@
 import { expect, type Locator, type Page } from '@playwright/test';
-import { TextArea } from './TextArea';
-import { Table } from './Table';
+import { AddVariableDialog } from './AddVariableDialog';
 import { Button } from './Button';
-import { Settings } from './Settings';
 import { Details } from './Details';
+import { Settings } from './Settings';
+import { Table } from './Table';
+import { TextArea } from './TextArea';
 
 export class VariableEditor {
   readonly page: Page;
   readonly search: TextArea;
   readonly tree: Table;
   readonly delete: Button;
-  readonly add: Button;
+  readonly add: AddVariableDialog;
   readonly locator: Locator;
   readonly settings: Settings;
   readonly details: Details;
@@ -24,7 +25,7 @@ export class VariableEditor {
     this.search = new TextArea(this.locator);
     this.tree = new Table(page, this.locator, ['label', 'label']);
     this.delete = new Button(this.locator, { name: 'Delete variable' });
-    this.add = new Button(this.locator, { name: 'Add variable' });
+    this.add = new AddVariableDialog(page, this.locator);
     this.settings = new Settings(this.locator);
     this.details = new Details(this.page, this.locator);
     this.detailsToggle = new Button(this.locator, { name: 'Details toggle' });
@@ -65,8 +66,7 @@ export class VariableEditor {
   }
 
   async addVariable() {
-    await this.add.click();
-    const createVariable = new Button(this.locator, { name: 'Create variable' });
-    await createVariable.click();
+    this.add.open();
+    this.add.createVariable();
   }
 }

--- a/packages/variable-editor/src/components/variables/master/AddVariableDialog.tsx
+++ b/packages/variable-editor/src/components/variables/master/AddVariableDialog.tsx
@@ -1,6 +1,6 @@
 import {
-  BasicSelect,
   Button,
+  Combobox,
   Dialog,
   DialogClose,
   DialogContent,
@@ -14,7 +14,8 @@ import {
 } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { type Table } from '@tanstack/react-table';
-import { addChildToFirstSelectedRow } from '../../../utils/tree/tree';
+import { useState } from 'react';
+import { addChildToFirstSelectedRow, keyOfFirstSelectedNonLeafRow } from '../../../utils/tree/tree';
 import type { TreePath } from '../../../utils/tree/types';
 import type { Variable } from '../data/variable';
 import './AddVariableDialog.css';
@@ -27,6 +28,12 @@ type AddVariableDialogProps = {
 };
 
 export const AddVariableDialog = ({ table, variables, setVariables, setSelectedVariablePath }: AddVariableDialogProps) => {
+  const [selectedNamespace, setSelectedNamespace] = useState('');
+
+  const onAddVariableDialogOpen = () => {
+    setSelectedNamespace(keyOfFirstSelectedNonLeafRow(table));
+  };
+
   const addVariable = () => {
     const newVariable: Variable = {
       name: '',
@@ -50,7 +57,12 @@ export const AddVariableDialog = ({ table, variables, setVariables, setSelectedV
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button className='add-variable-dialog-trigger-button' icon={IvyIcons.Plus} aria-label='Add variable' />
+        <Button
+          className='add-variable-dialog-trigger-button'
+          icon={IvyIcons.Plus}
+          onClick={onAddVariableDialogOpen}
+          aria-label='Add variable'
+        />
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>
@@ -61,7 +73,7 @@ export const AddVariableDialog = ({ table, variables, setVariables, setSelectedV
             <Input />
           </Fieldset>
           <Fieldset label='Namespace'>
-            <BasicSelect items={[]} />
+            <Combobox value={selectedNamespace} onChange={setSelectedNamespace} options={[]} />
           </Fieldset>
         </Flex>
         <DialogFooter>

--- a/packages/variable-editor/src/utils/tree/tree.test.ts
+++ b/packages/variable-editor/src/utils/tree/tree.test.ts
@@ -1,7 +1,14 @@
 import type { RowSelectionState, Table, Updater } from '@tanstack/react-table';
 import { createRow, createTable, getCoreRowModel } from '@tanstack/react-table';
 import type { TestNode } from './test-utils/types';
-import { addChildToFirstSelectedRow, deleteFirstSelectedRow, getPathOfRow, keyOfRow, treeGlobalFilter } from './tree';
+import {
+  addChildToFirstSelectedRow,
+  deleteFirstSelectedRow,
+  getPathOfRow,
+  keyOfFirstSelectedNonLeafRow,
+  keyOfRow,
+  treeGlobalFilter
+} from './tree';
 
 let data: Array<TestNode>;
 let newNode: TestNode;
@@ -242,6 +249,28 @@ describe('tree', () => {
 
     test('withParents', () => {
       expect(keyOfRow(table.getRowModel().rows[1].getLeafRows()[1].getLeafRows()[0])).toEqual('NameNode1.NameNode1.1.NameNode1.1.0');
+    });
+  });
+
+  describe('keyOfFirstSelectedNonLeafRow', () => {
+    test('noSelection', () => {
+      table.getState().rowSelection = {};
+      expect(keyOfFirstSelectedNonLeafRow(table)).toEqual('');
+    });
+
+    test('folderSelection', () => {
+      table.getState().rowSelection = { '1.1': true };
+      expect(keyOfFirstSelectedNonLeafRow(table)).toEqual('NameNode1.NameNode1.1');
+    });
+
+    test('rootLeafSelection', () => {
+      table.getState().rowSelection = { '0': true };
+      expect(keyOfFirstSelectedNonLeafRow(table)).toEqual('');
+    });
+
+    test('leafSelection', () => {
+      table.getState().rowSelection = { '1.1.0.0': true };
+      expect(keyOfFirstSelectedNonLeafRow(table)).toEqual('NameNode1.NameNode1.1.NameNode1.1.0');
     });
   });
 });

--- a/packages/variable-editor/src/utils/tree/tree.ts
+++ b/packages/variable-editor/src/utils/tree/tree.ts
@@ -103,6 +103,22 @@ export const treeGlobalFilter = <TNode extends TreeNode<TNode>>(data: Array<TNod
   return false;
 };
 
+export const keyOfFirstSelectedNonLeafRow = <TNode extends TreeNode<TNode>>(table: Table<TNode>) => {
+  const selectedRow = getFirstSelectedRow(table);
+  if (!selectedRow) {
+    return '';
+  }
+  if (selectedRow.subRows.length !== 0) {
+    return keyOfRow(selectedRow);
+  }
+
+  const parentRow = selectedRow.getParentRow();
+  if (parentRow) {
+    return keyOfRow(parentRow);
+  }
+  return '';
+};
+
 export const keyOfRow = <TNode extends TreeNode<TNode>>(row: Row<TNode>) => {
   const parentKey = keyOfParentRows(row);
   if (parentKey !== '') {


### PR DESCRIPTION
when the dialog to add a new variable is opened, the namespace field is filled with

- nothing, if no row is selected
- the key of the selected row, if it has children and therefore is a folder
- the key of the parent row, if it does not have children and therefore is a variable and a parent row exists
- nothing, if it does not have children and therefore is a variable but no parent exists (leaf node on topmost level)

added unittests for the logic mentioned above

added playwright tests for filling the namespace field, including new pageobjects

![fill-namespace](https://github.com/axonivy/config-editor-client/assets/141232142/8ba1dfc0-9241-4c9e-8b54-84cdb2f06074)
