### PR TITLE
XIVY-14357 automatically fill name of add dialog

### DIFF
--- a/integrations/standalone/tests/mock/variable-editor.spec.ts
+++ b/integrations/standalone/tests/mock/variable-editor.spec.ts
@@ -90,7 +90,7 @@ test.describe('VariableEditor', () => {
     await tree.row(5).click();
     await tree.row(5).expectValues(['useUserPassFlow', '']);
     await editor.add.open();
-    await editor.add.expectValues('', 'microsoft-connector.useUserPassFlow', 'microsoft-connector', 'microsoft-connector.useUserPassFlow');
+    await editor.add.expectValues('NewVariable', 'microsoft-connector.useUserPassFlow', 'microsoft-connector', 'microsoft-connector.useUserPassFlow');
   });
 
   test('collapse', async () => {

--- a/integrations/standalone/tests/pageobjects/Combobox.ts
+++ b/integrations/standalone/tests/pageobjects/Combobox.ts
@@ -27,5 +27,6 @@ export class Combobox {
     for (let i = 0; i < options.length; i++) {
       await expect(this.options.nth(i)).toHaveText(options[i]);
     }
+    await this.toggleMenu.click();
   }
 }

--- a/integrations/standalone/tests/pageobjects/VariableEditor.ts
+++ b/integrations/standalone/tests/pageobjects/VariableEditor.ts
@@ -66,7 +66,7 @@ export class VariableEditor {
   }
 
   async addVariable() {
-    this.add.open();
-    this.add.createVariable();
+    await this.add.open();
+    await this.add.createVariable();
   }
 }

--- a/packages/variable-editor/src/components/variables/master/AddVariableDialog.tsx
+++ b/packages/variable-editor/src/components/variables/master/AddVariableDialog.tsx
@@ -15,7 +15,7 @@ import {
 import { IvyIcons } from '@axonivy/ui-icons';
 import { type Table } from '@tanstack/react-table';
 import { useState } from 'react';
-import { addChildToFirstSelectedRow, keyOfFirstSelectedNonLeafRow, keysOfAllNonLeafRows } from '../../../utils/tree/tree';
+import { addChildToFirstSelectedRow, keyOfFirstSelectedNonLeafRow, keysOfAllNonLeafRows, newNodeName } from '../../../utils/tree/tree';
 import type { TreePath } from '../../../utils/tree/types';
 import type { Variable } from '../data/variable';
 import './AddVariableDialog.css';
@@ -32,6 +32,10 @@ export const AddVariableDialog = ({ table, variables, setVariables, setSelectedV
 
   const onAddVariableDialogOpen = () => {
     setSelectedNamespace(keyOfFirstSelectedNonLeafRow(table));
+  };
+
+  const newVariableName = () => {
+    return newNodeName(table, 'NewVariable');
   };
 
   const namespaceOptions = () => {
@@ -76,7 +80,7 @@ export const AddVariableDialog = ({ table, variables, setVariables, setSelectedV
         </DialogHeader>
         <Flex direction='column' gap={2}>
           <Fieldset label='Name'>
-            <Input />
+            <Input defaultValue={newVariableName()} />
           </Fieldset>
           <Fieldset label='Namespace'>
             <Combobox value={selectedNamespace} onChange={setSelectedNamespace} options={namespaceOptions()} />

--- a/packages/variable-editor/src/utils/tree/tree.test.ts
+++ b/packages/variable-editor/src/utils/tree/tree.test.ts
@@ -8,6 +8,7 @@ import {
   keyOfFirstSelectedNonLeafRow,
   keyOfRow,
   keysOfAllNonLeafRows,
+  newNodeName,
   treeGlobalFilter
 } from './tree';
 
@@ -250,6 +251,38 @@ describe('tree', () => {
 
     test('withParents', () => {
       expect(keyOfRow(table.getRowModel().rows[1].getLeafRows()[1].getLeafRows()[0])).toEqual('NameNode1.NameNode1.1.NameNode1.1.0');
+    });
+  });
+
+  describe('newNodeName', () => {
+    test('noSelection', () => {
+      table.getState().rowSelection = {};
+      expect(newNodeName(table, 'NewName')).toEqual('NewName');
+      table.getRowModel().rows[0].original.name = 'NewName';
+      expect(newNodeName(table, 'NewName')).toEqual('NewName2');
+      table.getRowModel().rows[1].original.name = 'NewName2';
+      expect(newNodeName(table, 'NewName')).toEqual('NewName3');
+    });
+
+    test('folderSelection', () => {
+      table.getState().rowSelection = { '1.1': true };
+      expect(newNodeName(table, 'NewName')).toEqual('NewName');
+      table.getRowModel().rows[1].subRows[1].subRows[0].original.name = 'NewName';
+      expect(newNodeName(table, 'NewName')).toEqual('NewName2');
+    });
+
+    test('rootLeafSelection', () => {
+      table.getState().rowSelection = { '0': true };
+      expect(newNodeName(table, 'NewName')).toEqual('NewName');
+      table.getRowModel().rows[0].original.name = 'NewName';
+      expect(newNodeName(table, 'NewName')).toEqual('NewName2');
+    });
+
+    test('leafSelection', () => {
+      table.getState().rowSelection = { '1.1.0.0': true };
+      expect(newNodeName(table, 'NewName')).toEqual('NewName');
+      table.getRowModel().rows[1].subRows[1].subRows[0].subRows[0].original.name = 'NewName';
+      expect(newNodeName(table, 'NewName')).toEqual('NewName2');
     });
   });
 

--- a/packages/variable-editor/src/utils/tree/tree.ts
+++ b/packages/variable-editor/src/utils/tree/tree.ts
@@ -103,20 +103,47 @@ export const treeGlobalFilter = <TNode extends TreeNode<TNode>>(data: Array<TNod
   return false;
 };
 
+export const newNodeName = <TNode extends TreeNode<TNode>>(table: Table<TNode>, baseName: string) => {
+  const takenNames = subRowsOfFirstSelectedNonLeafRow(table).map(row => row.original.name);
+  let newName = baseName;
+  let index = 2;
+  while (takenNames.includes(newName)) {
+    newName = `${baseName}${index}`;
+    index++;
+  }
+  return newName;
+};
+
+const subRowsOfFirstSelectedNonLeafRow = <TNode extends TreeNode<TNode>>(table: Table<TNode>) => {
+  const row = firstSelectedNonLeafRow(table);
+  if (!row) {
+    return table.getRowModel().rows;
+  }
+  return row.subRows;
+};
+
 export const keyOfFirstSelectedNonLeafRow = <TNode extends TreeNode<TNode>>(table: Table<TNode>) => {
-  const selectedRow = getFirstSelectedRow(table);
-  if (!selectedRow) {
+  const row = firstSelectedNonLeafRow(table);
+  if (!row) {
     return '';
   }
+  return keyOfRow(row);
+};
+
+const firstSelectedNonLeafRow = <TNode extends TreeNode<TNode>>(table: Table<TNode>) => {
+  const selectedRow = getFirstSelectedRow(table);
+  if (!selectedRow) {
+    return;
+  }
   if (hasChildren(selectedRow)) {
-    return keyOfRow(selectedRow);
+    return selectedRow;
   }
 
   const parentRow = selectedRow.getParentRow();
-  if (parentRow) {
-    return keyOfRow(parentRow);
+  if (!parentRow) {
+    return;
   }
-  return '';
+  return parentRow;
 };
 
 export const keysOfAllNonLeafRows = <TNode extends TreeNode<TNode>>(table: Table<TNode>) => {


### PR DESCRIPTION
the name field fill now be automatically filled with 'NewVariable'

if that variable name already exists on the initially selected namespace, an index will be added to the end. e.g. 'NewVariable2', 'NewVariable3', etc.

added unittests for finding the name to fill in and improved playwright test to check for it to be present when opening the add dialog.