### PR TITLE
XIVY-14357 validate name in add variable dialog

### DIFF
--- a/integrations/standalone/tests/mock/variable-editor.spec.ts
+++ b/integrations/standalone/tests/mock/variable-editor.spec.ts
@@ -1,4 +1,5 @@
 import { test } from '@playwright/test';
+import { describe } from 'node:test';
 import type { Table } from '../pageobjects/Table';
 import { VariableEditor } from '../pageobjects/VariableEditor';
 
@@ -91,6 +92,43 @@ test.describe('VariableEditor', () => {
     await tree.row(5).expectValues(['useUserPassFlow', '']);
     await editor.add.open();
     await editor.add.expectValues('NewVariable', 'microsoft-connector.useUserPassFlow', 'microsoft-connector', 'microsoft-connector.useUserPassFlow');
+  });
+
+  describe('addVariableDialogNameValidation', async () => {
+    test('onNameChange', async () => {
+      const add = editor.add;
+      await add.open();
+      await add.expectNoNameMessage();
+      await add.expectCreateEnabled();
+      await add.fillName('');
+      await add.expectNameMessage('Name cannot be empty.', 'error');
+      await add.expectCreateDisabled();
+      await add.fillName('microsoft-connector');
+      await add.expectNameMessage('Name is already present in this Namespace.', 'error');
+      await add.expectCreateDisabled();
+    });
+
+    test('onNamespaceChange', async () => {
+      const add = editor.add;
+      await add.open();
+      await add.fillName('appId');
+      await add.expectNoNameMessage();
+      await add.expectCreateEnabled();
+      await add.chooseNamespace('microsoft-connector');
+      await add.expectNameMessage('Name is already present in this Namespace.', 'error');
+      await add.expectCreateDisabled();
+    });
+
+    test('onNamespaceInput', async () => {
+      const add = editor.add;
+      await add.open();
+      await add.fillName('appId');
+      await add.expectNoNameMessage();
+      await add.expectCreateEnabled();
+      await add.fillNamespace('microsoft-connector');
+      await add.expectNameMessage('Name is already present in this Namespace.', 'error');
+      await add.expectCreateDisabled();
+    });
   });
 
   test('collapse', async () => {

--- a/integrations/standalone/tests/mock/variable-editor.spec.ts
+++ b/integrations/standalone/tests/mock/variable-editor.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-import { describe } from 'node:test';
 import type { Table } from '../pageobjects/Table';
 import { VariableEditor } from '../pageobjects/VariableEditor';
 
@@ -94,16 +93,16 @@ test.describe('VariableEditor', () => {
     await editor.add.expectValues('NewVariable', 'microsoft-connector.useUserPassFlow', 'microsoft-connector', 'microsoft-connector.useUserPassFlow');
   });
 
-  describe('addVariableDialogNameValidation', async () => {
+  test.describe('addVariableDialogNameValidation', async () => {
     test('onNameChange', async () => {
       const add = editor.add;
       await add.open();
       await add.expectNoNameMessage();
       await add.expectCreateEnabled();
-      await add.fillName('');
+      await add.name.fill('');
       await add.expectNameMessage('Name cannot be empty.', 'error');
       await add.expectCreateDisabled();
-      await add.fillName('microsoft-connector');
+      await add.name.fill('microsoft-connector');
       await add.expectNameMessage('Name is already present in this Namespace.', 'error');
       await add.expectCreateDisabled();
     });
@@ -111,10 +110,10 @@ test.describe('VariableEditor', () => {
     test('onNamespaceChange', async () => {
       const add = editor.add;
       await add.open();
-      await add.fillName('appId');
+      await add.name.fill('appId');
       await add.expectNoNameMessage();
       await add.expectCreateEnabled();
-      await add.chooseNamespace('microsoft-connector');
+      await add.namespace.choose('microsoft-connector');
       await add.expectNameMessage('Name is already present in this Namespace.', 'error');
       await add.expectCreateDisabled();
     });
@@ -122,10 +121,10 @@ test.describe('VariableEditor', () => {
     test('onNamespaceInput', async () => {
       const add = editor.add;
       await add.open();
-      await add.fillName('appId');
+      await add.name.fill('appId');
       await add.expectNoNameMessage();
       await add.expectCreateEnabled();
-      await add.fillNamespace('microsoft-connector');
+      await add.namespace.fill('microsoft-connector');
       await add.expectNameMessage('Name is already present in this Namespace.', 'error');
       await add.expectCreateDisabled();
     });

--- a/integrations/standalone/tests/pageobjects/AddVariableDialog.ts
+++ b/integrations/standalone/tests/pageobjects/AddVariableDialog.ts
@@ -1,17 +1,20 @@
-import type { Locator, Page } from '@playwright/test';
+import { type Locator, type Page } from '@playwright/test';
 import { Button } from './Button';
 import { Combobox } from './Combobox';
+import { FieldsetMessage } from './FieldsetMessage';
 import { TextArea } from './TextArea';
 
 export class AddVariableDialog {
   private readonly add: Button;
   private readonly name: TextArea;
+  private readonly nameMessage: FieldsetMessage;
   private readonly namespace: Combobox;
   private readonly create: Button;
 
   constructor(page: Page, parent: Locator) {
     this.add = new Button(parent, { name: 'Add variable' });
     this.name = new TextArea(parent);
+    this.nameMessage = new FieldsetMessage(parent, { label: 'Name' });
     this.namespace = new Combobox(page, parent);
     this.create = new Button(parent, { name: 'Create variable' });
   }
@@ -20,13 +23,42 @@ export class AddVariableDialog {
     await this.add.click();
   }
 
+  async fillName(name: string) {
+    await this.name.fill(name);
+  }
+
+  async fillNamespace(namespace: string) {
+    await this.namespace.fill(namespace);
+  }
+
+  async chooseNamespace(namespace: string) {
+    await this.namespace.choose(namespace);
+  }
+
   async expectValues(name: string, namespaceValue: string, ...namespaceOptions: Array<string>) {
     await this.name.expectValue(name);
     await this.namespace.expectValue(namespaceValue);
     await this.namespace.expectOptions(...namespaceOptions);
   }
 
+  async expectNoNameMessage() {
+    await this.nameMessage.expectDoesNotExist();
+  }
+
+  async expectNameMessage(message: string, variant: string) {
+    await this.nameMessage.expectMessage(message);
+    await this.nameMessage.expectVariant(variant);
+  }
+
   async createVariable() {
     await this.create.click();
+  }
+
+  async expectCreateEnabled() {
+    await this.create.expectEnabled();
+  }
+
+  async expectCreateDisabled() {
+    await this.create.expectDisabled();
   }
 }

--- a/integrations/standalone/tests/pageobjects/AddVariableDialog.ts
+++ b/integrations/standalone/tests/pageobjects/AddVariableDialog.ts
@@ -6,9 +6,9 @@ import { TextArea } from './TextArea';
 
 export class AddVariableDialog {
   private readonly add: Button;
-  private readonly name: TextArea;
+  readonly name: TextArea;
   private readonly nameMessage: FieldsetMessage;
-  private readonly namespace: Combobox;
+  readonly namespace: Combobox;
   private readonly create: Button;
 
   constructor(page: Page, parent: Locator) {
@@ -23,18 +23,6 @@ export class AddVariableDialog {
     await this.add.click();
   }
 
-  async fillName(name: string) {
-    await this.name.fill(name);
-  }
-
-  async fillNamespace(namespace: string) {
-    await this.namespace.fill(namespace);
-  }
-
-  async chooseNamespace(namespace: string) {
-    await this.namespace.choose(namespace);
-  }
-
   async expectValues(name: string, namespaceValue: string, ...namespaceOptions: Array<string>) {
     await this.name.expectValue(name);
     await this.namespace.expectValue(namespaceValue);
@@ -42,7 +30,7 @@ export class AddVariableDialog {
   }
 
   async expectNoNameMessage() {
-    await this.nameMessage.expectDoesNotExist();
+    await this.nameMessage.expectToBeHidden();
   }
 
   async expectNameMessage(message: string, variant: string) {

--- a/integrations/standalone/tests/pageobjects/Button.ts
+++ b/integrations/standalone/tests/pageobjects/Button.ts
@@ -18,4 +18,12 @@ export class Button {
   async expectDataState(dataState: string) {
     await expect(this.locator).toHaveAttribute('data-state', dataState);
   }
+
+  async expectEnabled() {
+    await expect(this.locator).toBeEnabled();
+  }
+
+  async expectDisabled() {
+    await expect(this.locator).toBeDisabled();
+  }
 }

--- a/integrations/standalone/tests/pageobjects/Combobox.ts
+++ b/integrations/standalone/tests/pageobjects/Combobox.ts
@@ -17,6 +17,15 @@ export class Combobox {
     this.toggleMenu = new Button(parentLocator, { name: 'toggle menu' });
   }
 
+  async fill(value: string) {
+    await this.locator.fill(value);
+  }
+
+  async choose(value: string) {
+    await this.toggleMenu.click();
+    await this.page.getByRole('option', { name: value }).first().click();
+  }
+
   async expectValue(value: string | RegExp) {
     await expect(this.locator).toHaveValue(value);
   }

--- a/integrations/standalone/tests/pageobjects/FieldsetMessage.ts
+++ b/integrations/standalone/tests/pageobjects/FieldsetMessage.ts
@@ -7,8 +7,8 @@ export class FieldsetMessage {
     this.locator = parentLocator.getByLabel(options.label, { exact: true }).locator('.ui-message');
   }
 
-  async expectDoesNotExist() {
-    await expect(this.locator).toHaveCount(0);
+  async expectToBeHidden() {
+    await expect(this.locator).toBeHidden();
   }
 
   async expectMessage(message: string) {

--- a/integrations/standalone/tests/pageobjects/FieldsetMessage.ts
+++ b/integrations/standalone/tests/pageobjects/FieldsetMessage.ts
@@ -1,0 +1,21 @@
+import { expect, type Locator } from '@playwright/test';
+
+export class FieldsetMessage {
+  private readonly locator: Locator;
+
+  constructor(parentLocator: Locator, options: { label: string }) {
+    this.locator = parentLocator.getByLabel(options.label, { exact: true }).locator('.ui-message');
+  }
+
+  async expectDoesNotExist() {
+    await expect(this.locator).toHaveCount(0);
+  }
+
+  async expectMessage(message: string) {
+    await expect(this.locator).toHaveText(message);
+  }
+
+  async expectVariant(variant: string) {
+    await expect(this.locator).toHaveAttribute('data-state', variant);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,18 +71,18 @@
       "link": true
     },
     "node_modules/@axonivy/jsonrpc": {
-      "version": "11.4.0-next.217",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/jsonrpc/-/jsonrpc-11.4.0-next.217.tgz",
-      "integrity": "sha512-iTdsECCKfcPUxslr+Ry/209RIWijiZwPz2bxzETZb0xY87thpK4SNYZGXUTSOY9Vz97HE06m1Qdsxec7Bmcn1g==",
+      "version": "11.4.0-next.227",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/jsonrpc/-/jsonrpc-11.4.0-next.227.tgz",
+      "integrity": "sha512-IrdG4Vh+Pz0IJ5kLWfiWu6Sy7/HxpCH52P1ulmj30fFUhS252VLee3P+8g38TovWJer6e5vxCnEu6VFylua7KQ==",
       "dependencies": {
         "vscode-jsonrpc": "^8.2.0",
         "vscode-ws-jsonrpc": "^3.0.0"
       }
     },
     "node_modules/@axonivy/ui-components": {
-      "version": "11.4.0-next.217",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-components/-/ui-components-11.4.0-next.217.tgz",
-      "integrity": "sha512-YjVA3kJgPHRxj9ZIIXUdj26XX8Od5ltVS0C1qRTiCA1UCm9A49Jnl/u5OLktq/ZUix/jLAe0BC5aOYkLG57TEg==",
+      "version": "11.4.0-next.227",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-components/-/ui-components-11.4.0-next.227.tgz",
+      "integrity": "sha512-3cKyhqg2sYXDHu1koiERhFc45zVde1FhRxYOHwRiXmIxd0XvKgaSvWJzYfSqxMmNddie8ULdefp+5N3ljzjXZw==",
       "dependencies": {
         "@radix-ui/react-accordion": "1.1.2",
         "@radix-ui/react-checkbox": "1.0.4",
@@ -96,6 +96,7 @@
         "@radix-ui/react-separator": "1.0.3",
         "@radix-ui/react-switch": "1.0.3",
         "@radix-ui/react-tabs": "1.0.4",
+        "@radix-ui/react-toggle-group": "1.1.0",
         "@radix-ui/react-tooltip": "1.0.7",
         "@react-aria/dnd": "^3.5.3",
         "@tanstack/react-table": "^8.13.2",
@@ -110,9 +111,9 @@
       }
     },
     "node_modules/@axonivy/ui-icons": {
-      "version": "11.4.0-next.217",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-icons/-/ui-icons-11.4.0-next.217.tgz",
-      "integrity": "sha512-LjpbjTahxakD2otodtCR7Si+RHsqfBnhwbfanZnt62sxrJgccbJp0Lh5GyTBkA9q2zC4CkN3cfZ8yhT6va0XhA=="
+      "version": "11.4.0-next.227",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-icons/-/ui-icons-11.4.0-next.227.tgz",
+      "integrity": "sha512-LIL/RrotXaSKuHuAG6RMTOgK9jshQzC0uiajcK3i/yFofl3yQF9DjhL6QyJPf8jLYPZfiCzCxSqhD+LFssYf0A=="
     },
     "node_modules/@axonivy/variable-editor": {
       "resolved": "packages/variable-editor",
@@ -2986,6 +2987,350 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.0.tgz",
+      "integrity": "sha512-gwoxaKZ0oJ4vIgzsfESBuSgJNdc0rv12VhHgcqN0TEJmmZixXG/2XpsLK8kzNWYcnaoRIEEQc0bEi3dIvdUpjw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.0.tgz",
+      "integrity": "sha512-PpTJV68dZU2oqqgq75Uzto5o/XfOVgkrJ9rulVmfTKxWp3HfUjHE6CP/WLRR4AzPX9HWxw7vFow2me85Yu+Naw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-roving-focus": "1.1.0",
+        "@radix-ui/react-toggle": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.0.tgz",
+      "integrity": "sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA=="
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.0.tgz",
+      "integrity": "sha512-GZsZslMJEyo1VKm5L1ZJY8tGDxZNPAoUeQUIbKeJfoi7Q4kmig5AsgLMYYuyYbfjd8fBmFORAIwYAkXMnXZgZw==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz",
+      "integrity": "sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-context": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.0.tgz",
+      "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-direction": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.0.tgz",
+      "integrity": "sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-id": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.0.tgz",
+      "integrity": "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.0.tgz",
+      "integrity": "sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.0.tgz",
+      "integrity": "sha512-EA6AMGeq9AEeQDeSH0aZgG198qkfHSbvWTf1HvoDmOB5bBG/qTxjYMWUKMnYiV6J/iP/J8MEFSuB2zRU2n7ODA==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-collection": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
+      "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+      "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
+      "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
+      "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.0.tgz",
+      "integrity": "sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA=="
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz",
+      "integrity": "sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.0.tgz",
+      "integrity": "sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
+      "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+      "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
+      "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -15463,9 +15808,9 @@
       "version": "11.4.0-next",
       "license": "Apache-2.0",
       "dependencies": {
-        "@axonivy/jsonrpc": "~11.4.0-next.217",
-        "@axonivy/ui-components": "~11.4.0-next.217",
-        "@axonivy/ui-icons": "~11.4.0-next.217",
+        "@axonivy/jsonrpc": "~11.4.0-next.227",
+        "@axonivy/ui-components": "~11.4.0-next.227",
+        "@axonivy/ui-icons": "~11.4.0-next.227",
         "@tanstack/react-query": "5.32.1",
         "@tanstack/react-query-devtools": "5.32.1",
         "react": "^18.2.0",

--- a/packages/variable-editor/package.json
+++ b/packages/variable-editor/package.json
@@ -17,9 +17,9 @@
   "types": "lib/index",
   "source": "src/index",
   "dependencies": {
-    "@axonivy/jsonrpc": "~11.4.0-next.217",
-    "@axonivy/ui-components": "~11.4.0-next.217",
-    "@axonivy/ui-icons": "~11.4.0-next.217",
+    "@axonivy/jsonrpc": "~11.4.0-next.227",
+    "@axonivy/ui-components": "~11.4.0-next.227",
+    "@axonivy/ui-icons": "~11.4.0-next.227",
     "@tanstack/react-query": "5.32.1",
     "@tanstack/react-query-devtools": "5.32.1",
     "react": "^18.2.0",

--- a/packages/variable-editor/src/components/variables/data/validation-utils.test.ts
+++ b/packages/variable-editor/src/components/variables/data/validation-utils.test.ts
@@ -1,7 +1,7 @@
 import type { Row } from '@tanstack/react-table';
 import type { ValidationMessages } from '../../../protocol/types';
 import { mockRow } from './test-utils/types';
-import { containsError, containsWarning, toValidationMessageVariant, validationMessagesOfRow } from './validation-utils';
+import { containsError, containsWarning, toValidationMessageVariant, validateName, validationMessagesOfRow } from './validation-utils';
 import type { Variable } from './variable';
 
 let validationMessages: ValidationMessages;
@@ -86,6 +86,26 @@ describe('validaton-utils', () => {
 
     test('default', () => {
       expect(toValidationMessageVariant(42)).toEqual('info');
+    });
+  });
+
+  describe('validateName', () => {
+    test('valid', () => {
+      expect(validateName('Name', ['AnotherName'])).toBeUndefined();
+    });
+
+    describe('blank', () => {
+      test('empty', () => {
+        expect(validateName('', [])).toEqual('Name cannot be empty.');
+      });
+
+      test('whitespace', () => {
+        expect(validateName('   ', [])).toEqual('Name cannot be empty.');
+      });
+    });
+
+    test('taken', () => {
+      expect(validateName('Name', ['Name'])).toEqual('Name is already present in this Namespace.');
     });
   });
 });

--- a/packages/variable-editor/src/components/variables/data/validation-utils.ts
+++ b/packages/variable-editor/src/components/variables/data/validation-utils.ts
@@ -33,3 +33,13 @@ export const toValidationMessageVariant = (severity: number) => {
       return 'info';
   }
 };
+
+export const validateName = (name: string, takenNames: Array<string>) => {
+  if (name.trim() === '') {
+    return 'Name cannot be empty.';
+  }
+  if (takenNames.includes(name)) {
+    return 'Name is already present in this Namespace.';
+  }
+  return;
+};

--- a/packages/variable-editor/src/components/variables/master/AddVariableDialog.tsx
+++ b/packages/variable-editor/src/components/variables/master/AddVariableDialog.tsx
@@ -15,7 +15,7 @@ import {
 } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { type Table } from '@tanstack/react-table';
-import { useMemo, useState, type ChangeEvent, type FormEvent } from 'react';
+import { useMemo, useState } from 'react';
 import {
   addChildToFirstSelectedRow,
   keyOfFirstSelectedNonLeafRow,
@@ -47,21 +47,9 @@ export const AddVariableDialog = ({ table, variables, setVariables, setSelectedV
     return { message: validationMessage, variant: 'error' };
   }, [name, namespace, table]);
 
-  const handleAddVariableDialogOpen = () => {
+  const initializeVariableDialog = () => {
     setName(newNodeName(table, 'NewVariable'));
     setNamespace(keyOfFirstSelectedNonLeafRow(table));
-  };
-
-  const handleNameInputChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setName(event.target.value);
-  };
-
-  const handleNamespaceComboboxChange = (value: string) => {
-    setNamespace(value);
-  };
-
-  const handleNamespaceComboboxInput = (event: FormEvent<HTMLInputElement>) => {
-    setNamespace(event.currentTarget.value);
   };
 
   const namespaceOptions = () => {
@@ -100,7 +88,7 @@ export const AddVariableDialog = ({ table, variables, setVariables, setSelectedV
         <Button
           className='add-variable-dialog-trigger-button'
           icon={IvyIcons.Plus}
-          onClick={handleAddVariableDialogOpen}
+          onClick={initializeVariableDialog}
           aria-label='Add variable'
         />
       </DialogTrigger>
@@ -110,13 +98,20 @@ export const AddVariableDialog = ({ table, variables, setVariables, setSelectedV
         </DialogHeader>
         <Flex direction='column' gap={2}>
           <Fieldset label='Name' message={nameValidationMessage} aria-label='Name'>
-            <Input defaultValue={name} onChange={handleNameInputChange} />
+            <Input
+              value={name}
+              onChange={event => {
+                setName(event.target.value);
+              }}
+            />
           </Fieldset>
           <Fieldset label='Namespace'>
             <Combobox
               value={namespace}
-              onChange={handleNamespaceComboboxChange}
-              onInput={handleNamespaceComboboxInput}
+              onChange={setNamespace}
+              onInput={event => {
+                setNamespace(event.currentTarget.value);
+              }}
               options={namespaceOptions()}
             />
           </Fieldset>

--- a/packages/variable-editor/src/components/variables/master/AddVariableDialog.tsx
+++ b/packages/variable-editor/src/components/variables/master/AddVariableDialog.tsx
@@ -10,13 +10,21 @@ import {
   DialogTrigger,
   Fieldset,
   Flex,
-  Input
+  Input,
+  type MessageData
 } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { type Table } from '@tanstack/react-table';
-import { useState } from 'react';
-import { addChildToFirstSelectedRow, keyOfFirstSelectedNonLeafRow, keysOfAllNonLeafRows, newNodeName } from '../../../utils/tree/tree';
+import { useMemo, useState, type ChangeEvent, type FormEvent } from 'react';
+import {
+  addChildToFirstSelectedRow,
+  keyOfFirstSelectedNonLeafRow,
+  keysOfAllNonLeafRows,
+  newNodeName,
+  subRowNamesOfRow
+} from '../../../utils/tree/tree';
 import type { TreePath } from '../../../utils/tree/types';
+import { validateName } from '../data/validation-utils';
 import type { Variable } from '../data/variable';
 import './AddVariableDialog.css';
 
@@ -28,14 +36,32 @@ type AddVariableDialogProps = {
 };
 
 export const AddVariableDialog = ({ table, variables, setVariables, setSelectedVariablePath }: AddVariableDialogProps) => {
-  const [selectedNamespace, setSelectedNamespace] = useState('');
+  const [name, setName] = useState('');
+  const [namespace, setNamespace] = useState('');
 
-  const onAddVariableDialogOpen = () => {
-    setSelectedNamespace(keyOfFirstSelectedNonLeafRow(table));
+  const nameValidationMessage = useMemo((): MessageData => {
+    const validationMessage = validateName(name, subRowNamesOfRow(namespace, table));
+    if (!validationMessage) {
+      return;
+    }
+    return { message: validationMessage, variant: 'error' };
+  }, [name, namespace, table]);
+
+  const handleAddVariableDialogOpen = () => {
+    setName(newNodeName(table, 'NewVariable'));
+    setNamespace(keyOfFirstSelectedNonLeafRow(table));
   };
 
-  const newVariableName = () => {
-    return newNodeName(table, 'NewVariable');
+  const handleNameInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setName(event.target.value);
+  };
+
+  const handleNamespaceComboboxChange = (value: string) => {
+    setNamespace(value);
+  };
+
+  const handleNamespaceComboboxInput = (event: FormEvent<HTMLInputElement>) => {
+    setNamespace(event.currentTarget.value);
   };
 
   const namespaceOptions = () => {
@@ -64,13 +90,17 @@ export const AddVariableDialog = ({ table, variables, setVariables, setSelectedV
     setVariables(addChildToFirstSelectedRowReturnValue.newData);
   };
 
+  const allInputsValid = () => {
+    return !nameValidationMessage;
+  };
+
   return (
     <Dialog>
       <DialogTrigger asChild>
         <Button
           className='add-variable-dialog-trigger-button'
           icon={IvyIcons.Plus}
-          onClick={onAddVariableDialogOpen}
+          onClick={handleAddVariableDialogOpen}
           aria-label='Add variable'
         />
       </DialogTrigger>
@@ -79,16 +109,28 @@ export const AddVariableDialog = ({ table, variables, setVariables, setSelectedV
           <DialogTitle>New Variable</DialogTitle>
         </DialogHeader>
         <Flex direction='column' gap={2}>
-          <Fieldset label='Name'>
-            <Input defaultValue={newVariableName()} />
+          <Fieldset label='Name' message={nameValidationMessage} aria-label='Name'>
+            <Input defaultValue={name} onChange={handleNameInputChange} />
           </Fieldset>
           <Fieldset label='Namespace'>
-            <Combobox value={selectedNamespace} onChange={setSelectedNamespace} options={namespaceOptions()} />
+            <Combobox
+              value={namespace}
+              onChange={handleNamespaceComboboxChange}
+              onInput={handleNamespaceComboboxInput}
+              options={namespaceOptions()}
+            />
           </Fieldset>
         </Flex>
         <DialogFooter>
           <DialogClose asChild>
-            <Button variant='primary' size='large' type='submit' aria-label='Create variable' onClick={addVariable}>
+            <Button
+              variant='primary'
+              size='large'
+              type='submit'
+              aria-label='Create variable'
+              disabled={!allInputsValid()}
+              onClick={addVariable}
+            >
               Create Variable
             </Button>
           </DialogClose>

--- a/packages/variable-editor/src/utils/tree/tree.test.ts
+++ b/packages/variable-editor/src/utils/tree/tree.test.ts
@@ -9,6 +9,7 @@ import {
   keyOfRow,
   keysOfAllNonLeafRows,
   newNodeName,
+  subRowNamesOfRow,
   treeGlobalFilter
 } from './tree';
 
@@ -25,15 +26,15 @@ beforeEach(() => {
       name: 'NameNode1',
       value: '',
       children: [
-        { name: 'NameNode1.0', value: 'ValueNode1.0', children: [] },
+        { name: 'NameNode10', value: 'ValueNode10', children: [] },
         {
-          name: 'NameNode1.1',
+          name: 'NameNode11',
           value: '',
           children: [
             {
-              name: 'NameNode1.1.0',
+              name: 'NameNode110',
               value: '',
-              children: [{ name: 'NameNode1.1.0.0', value: 'ValueNode1.1.0.0', children: [] }]
+              children: [{ name: 'NameNode1100', value: 'ValueNode1100', children: [] }]
             }
           ]
         }
@@ -250,7 +251,7 @@ describe('tree', () => {
     });
 
     test('withParents', () => {
-      expect(keyOfRow(table.getRowModel().rows[1].getLeafRows()[1].getLeafRows()[0])).toEqual('NameNode1.NameNode1.1.NameNode1.1.0');
+      expect(keyOfRow(table.getRowModel().rows[1].getLeafRows()[1].getLeafRows()[0])).toEqual('NameNode1.NameNode11.NameNode110');
     });
   });
 
@@ -294,7 +295,7 @@ describe('tree', () => {
 
     test('folderSelection', () => {
       table.getState().rowSelection = { '1.1': true };
-      expect(keyOfFirstSelectedNonLeafRow(table)).toEqual('NameNode1.NameNode1.1');
+      expect(keyOfFirstSelectedNonLeafRow(table)).toEqual('NameNode1.NameNode11');
     });
 
     test('rootLeafSelection', () => {
@@ -304,16 +305,34 @@ describe('tree', () => {
 
     test('leafSelection', () => {
       table.getState().rowSelection = { '1.1.0.0': true };
-      expect(keyOfFirstSelectedNonLeafRow(table)).toEqual('NameNode1.NameNode1.1.NameNode1.1.0');
+      expect(keyOfFirstSelectedNonLeafRow(table)).toEqual('NameNode1.NameNode11.NameNode110');
     });
   });
 
   test('keysOfAllNonLeafRows', () => {
     expect(keysOfAllNonLeafRows(table)).toEqual([
       'NameNode1',
-      'NameNode1.NameNode1.1',
-      'NameNode1.NameNode1.1.NameNode1.1.0',
+      'NameNode1.NameNode11',
+      'NameNode1.NameNode11.NameNode110',
       'SearchForParentName'
     ]);
+  });
+
+  describe('subRowNamesOfRow', () => {
+    test('root', () => {
+      expect(subRowNamesOfRow('', table)).toEqual(['NameNode0', 'NameNode1', 'SearchForParentName']);
+    });
+
+    test('singlePart', () => {
+      expect(subRowNamesOfRow('NameNode1', table)).toEqual(['NameNode10', 'NameNode11']);
+    });
+
+    test('multipleParts', () => {
+      expect(subRowNamesOfRow('NameNode1.NameNode11.NameNode110', table)).toEqual(['NameNode1100']);
+    });
+
+    test('notPresent', () => {
+      expect(subRowNamesOfRow('This.Key.Is.Not.Present', table)).toEqual([]);
+    });
   });
 });

--- a/packages/variable-editor/src/utils/tree/tree.ts
+++ b/packages/variable-editor/src/utils/tree/tree.ts
@@ -168,3 +168,23 @@ const keyOfParentRows = <TNode extends TreeNode<TNode>>(row: Row<TNode>) => {
     .map(parentRow => parentRow.original.name)
     .join('.');
 };
+
+export const subRowNamesOfRow = <TNode extends TreeNode<TNode>>(key: string, table: Table<TNode>) => {
+  return subRowsOfRow(key, table).map(row => row.original.name);
+};
+
+const subRowsOfRow = <TNode extends TreeNode<TNode>>(key: string, table: Table<TNode>) => {
+  let currentSubRows = table.getCoreRowModel().rows;
+  if (key === '') {
+    return currentSubRows;
+  }
+
+  for (const keyPart of key.split('.')) {
+    const nextRow = currentSubRows.find(row => row.original.name === keyPart);
+    if (nextRow === undefined) {
+      return [];
+    }
+    currentSubRows = nextRow.subRows;
+  }
+  return currentSubRows;
+};


### PR DESCRIPTION
name cannot be empty or already present in the provided namespace

validation updates on changes made to the name input field or the namespace combobox

create button is disabled if any validation messages are present

added unittests and playwright tests including new pageobjects

![name-validation](https://github.com/axonivy/config-editor-client/assets/141232142/d6cad9ea-8f0e-45de-a026-98125c27eaa0)
