### PR TITLE
XIVY-14357 validate namespace field of add dialog

### DIFF
--- a/integrations/standalone/tests/mock/variable-editor.spec.ts
+++ b/integrations/standalone/tests/mock/variable-editor.spec.ts
@@ -93,39 +93,51 @@ test.describe('VariableEditor', () => {
     await editor.add.expectValues('NewVariable', 'microsoft-connector.useUserPassFlow', 'microsoft-connector', 'microsoft-connector.useUserPassFlow');
   });
 
-  test.describe('addVariableDialogNameValidation', async () => {
-    test('onNameChange', async () => {
-      const add = editor.add;
-      await add.open();
-      await add.expectNoNameMessage();
-      await add.expectCreateEnabled();
-      await add.name.fill('');
-      await add.expectNameMessage('Name cannot be empty.', 'error');
-      await add.expectCreateDisabled();
-      await add.name.fill('microsoft-connector');
-      await add.expectNameMessage('Name is already present in this Namespace.', 'error');
-      await add.expectCreateDisabled();
+  test.describe('addVariableDialogValidation', async () => {
+    test.describe('name', async () => {
+      test('onNameChange', async () => {
+        const add = editor.add;
+        await add.open();
+        await add.nameMessage.expectToBeHidden();
+        await add.expectCreateEnabled();
+        await add.name.fill('');
+        await add.nameMessage.expectErrorMessage('Name cannot be empty.');
+        await add.expectCreateDisabled();
+        await add.name.fill('microsoft-connector');
+        await add.nameMessage.expectErrorMessage('Name is already present in this Namespace.');
+        await add.expectCreateDisabled();
+      });
+
+      test('onNamespaceChange', async () => {
+        const add = editor.add;
+        await add.open();
+        await add.name.fill('appId');
+        await add.nameMessage.expectToBeHidden();
+        await add.expectCreateEnabled();
+        await add.namespace.choose('microsoft-connector');
+        await add.nameMessage.expectErrorMessage('Name is already present in this Namespace.');
+        await add.expectCreateDisabled();
+      });
+
+      test('onNamespaceInput', async () => {
+        const add = editor.add;
+        await add.open();
+        await add.name.fill('appId');
+        await add.nameMessage.expectToBeHidden();
+        await add.expectCreateEnabled();
+        await add.namespace.fill('microsoft-connector');
+        await add.nameMessage.expectErrorMessage('Name is already present in this Namespace.');
+        await add.expectCreateDisabled();
+      });
     });
 
-    test('onNamespaceChange', async () => {
+    test('namespace', async () => {
       const add = editor.add;
       await add.open();
-      await add.name.fill('appId');
-      await add.expectNoNameMessage();
+      await add.namespaceMessage.expectToBeHidden();
       await add.expectCreateEnabled();
-      await add.namespace.choose('microsoft-connector');
-      await add.expectNameMessage('Name is already present in this Namespace.', 'error');
-      await add.expectCreateDisabled();
-    });
-
-    test('onNamespaceInput', async () => {
-      const add = editor.add;
-      await add.open();
-      await add.name.fill('appId');
-      await add.expectNoNameMessage();
-      await add.expectCreateEnabled();
-      await add.namespace.fill('microsoft-connector');
-      await add.expectNameMessage('Name is already present in this Namespace.', 'error');
+      await add.namespace.fill('microsoft-connector.appId.New.Namespace');
+      await add.namespaceMessage.expectErrorMessage("Namespace 'microsoft-connector.appId' is already present but not a folder.");
       await add.expectCreateDisabled();
     });
   });

--- a/integrations/standalone/tests/mock/variable-editor.spec.ts
+++ b/integrations/standalone/tests/mock/variable-editor.spec.ts
@@ -137,7 +137,7 @@ test.describe('VariableEditor', () => {
       await add.namespaceMessage.expectToBeHidden();
       await add.expectCreateEnabled();
       await add.namespace.fill('microsoft-connector.appId.New.Namespace');
-      await add.namespaceMessage.expectErrorMessage("Namespace 'microsoft-connector.appId' is already present but not a folder.");
+      await add.namespaceMessage.expectErrorMessage("Namespace 'microsoft-connector.appId' is not a folder, you cannot add a child to it.");
       await add.expectCreateDisabled();
     });
   });

--- a/integrations/standalone/tests/pageobjects/AddVariableDialog.ts
+++ b/integrations/standalone/tests/pageobjects/AddVariableDialog.ts
@@ -7,8 +7,9 @@ import { TextArea } from './TextArea';
 export class AddVariableDialog {
   private readonly add: Button;
   readonly name: TextArea;
-  private readonly nameMessage: FieldsetMessage;
+  readonly nameMessage: FieldsetMessage;
   readonly namespace: Combobox;
+  readonly namespaceMessage: FieldsetMessage;
   private readonly create: Button;
 
   constructor(page: Page, parent: Locator) {
@@ -16,6 +17,7 @@ export class AddVariableDialog {
     this.name = new TextArea(parent);
     this.nameMessage = new FieldsetMessage(parent, { label: 'Name' });
     this.namespace = new Combobox(page, parent);
+    this.namespaceMessage = new FieldsetMessage(parent, { label: 'Namespace' });
     this.create = new Button(parent, { name: 'Create variable' });
   }
 
@@ -27,15 +29,6 @@ export class AddVariableDialog {
     await this.name.expectValue(name);
     await this.namespace.expectValue(namespaceValue);
     await this.namespace.expectOptions(...namespaceOptions);
-  }
-
-  async expectNoNameMessage() {
-    await this.nameMessage.expectToBeHidden();
-  }
-
-  async expectNameMessage(message: string, variant: string) {
-    await this.nameMessage.expectMessage(message);
-    await this.nameMessage.expectVariant(variant);
   }
 
   async createVariable() {

--- a/integrations/standalone/tests/pageobjects/FieldsetMessage.ts
+++ b/integrations/standalone/tests/pageobjects/FieldsetMessage.ts
@@ -11,11 +11,8 @@ export class FieldsetMessage {
     await expect(this.locator).toBeHidden();
   }
 
-  async expectMessage(message: string) {
+  async expectErrorMessage(message: string) {
     await expect(this.locator).toHaveText(message);
-  }
-
-  async expectVariant(variant: string) {
-    await expect(this.locator).toHaveAttribute('data-state', variant);
+    await expect(this.locator).toHaveAttribute('data-state', 'error');
   }
 }

--- a/packages/variable-editor/src/components/variables/data/test-utils/types.ts
+++ b/packages/variable-editor/src/components/variables/data/test-utils/types.ts
@@ -17,3 +17,7 @@ export const mockRow = (name: string, parentName: string): DeepPartial<Row<Varia
     ]
   };
 };
+
+export const variable = (name: string, children: Array<Variable>) => {
+  return { name: name, children: children } as Variable;
+};

--- a/packages/variable-editor/src/components/variables/data/validation-utils.test.ts
+++ b/packages/variable-editor/src/components/variables/data/validation-utils.test.ts
@@ -146,21 +146,21 @@ describe('validaton-utils', () => {
     describe('invalid', () => {
       test('firstPartIsNotAFolder', () => {
         expect(validateNamespace('NameNode0.New.Namespace', variables)).toEqual({
-          message: "Namespace 'NameNode0' is already present but not a folder.",
+          message: "Namespace 'NameNode0' is not a folder, you cannot add a child to it.",
           variant: 'error'
         });
       });
 
       test('middlePartIsNotAFolder', () => {
         expect(validateNamespace('NameNode1.NameNode10.New.Namespace', variables)).toEqual({
-          message: "Namespace 'NameNode1.NameNode10' is already present but not a folder.",
+          message: "Namespace 'NameNode1.NameNode10' is not a folder, you cannot add a child to it.",
           variant: 'error'
         });
       });
 
       test('lastPartIsNotAFolder', () => {
         expect(validateNamespace('NameNode1.NameNode11.NameNode110', variables)).toEqual({
-          message: "Namespace 'NameNode1.NameNode11.NameNode110' is already present but not a folder.",
+          message: "Namespace 'NameNode1.NameNode11.NameNode110' is not a folder, you cannot add a child to it.",
           variant: 'error'
         });
       });

--- a/packages/variable-editor/src/components/variables/data/validation-utils.ts
+++ b/packages/variable-editor/src/components/variables/data/validation-utils.ts
@@ -54,7 +54,7 @@ export const validateNamespace = (namespace: string, variables: Array<Variable>)
       return;
     }
     if (!hasChildren(nextVariable)) {
-      return toErrorMessage("Namespace '" + keyParts.slice(0, index + 1).join('.') + "' is already present but not a folder.");
+      return toErrorMessage("Namespace '" + keyParts.slice(0, index + 1).join('.') + "' is not a folder, you cannot add a child to it.");
     }
     currentVariables = nextVariable.children;
   }

--- a/packages/variable-editor/src/components/variables/master/AddVariableDialog.tsx
+++ b/packages/variable-editor/src/components/variables/master/AddVariableDialog.tsx
@@ -10,8 +10,7 @@ import {
   DialogTrigger,
   Fieldset,
   Flex,
-  Input,
-  type MessageData
+  Input
 } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { type Table } from '@tanstack/react-table';
@@ -24,7 +23,7 @@ import {
   subRowNamesOfRow
 } from '../../../utils/tree/tree';
 import type { TreePath } from '../../../utils/tree/types';
-import { validateName } from '../data/validation-utils';
+import { validateName, validateNamespace } from '../data/validation-utils';
 import type { Variable } from '../data/variable';
 import './AddVariableDialog.css';
 
@@ -39,13 +38,13 @@ export const AddVariableDialog = ({ table, variables, setVariables, setSelectedV
   const [name, setName] = useState('');
   const [namespace, setNamespace] = useState('');
 
-  const nameValidationMessage = useMemo((): MessageData => {
-    const validationMessage = validateName(name, subRowNamesOfRow(namespace, table));
-    if (!validationMessage) {
-      return;
-    }
-    return { message: validationMessage, variant: 'error' };
+  const nameValidationMessage = useMemo(() => {
+    return validateName(name, subRowNamesOfRow(namespace, table));
   }, [name, namespace, table]);
+
+  const namespaceValidationMessage = useMemo(() => {
+    return validateNamespace(namespace, variables);
+  }, [namespace, variables]);
 
   const initializeVariableDialog = () => {
     setName(newNodeName(table, 'NewVariable'));
@@ -79,7 +78,7 @@ export const AddVariableDialog = ({ table, variables, setVariables, setSelectedV
   };
 
   const allInputsValid = () => {
-    return !nameValidationMessage;
+    return !nameValidationMessage && !namespaceValidationMessage;
   };
 
   return (
@@ -105,7 +104,7 @@ export const AddVariableDialog = ({ table, variables, setVariables, setSelectedV
               }}
             />
           </Fieldset>
-          <Fieldset label='Namespace'>
+          <Fieldset label='Namespace' message={namespaceValidationMessage} aria-label='Namespace'>
             <Combobox
               value={namespace}
               onChange={setNamespace}


### PR DESCRIPTION
check that the input namespace does not collide with any known variables

![namespace-validation](https://github.com/axonivy/config-editor-client/assets/141232142/e59954d4-a1e8-4ffb-baf5-ef263f7ac906)
