### PR TITLE
Feature/xivy 14263 improve overwrite dialog

### DIFF
--- a/packages/variable-editor/src/VariableEditor.tsx
+++ b/packages/variable-editor/src/VariableEditor.tsx
@@ -31,8 +31,7 @@ function VariableEditor(props: EditorProps) {
     return {
       data: () => genQueryKey('data', context),
       saveData: () => genQueryKey('saveData', context),
-      validate: () => genQueryKey('validate', context),
-      knownVariables: () => genQueryKey('meta/knownVariables', context)
+      validate: () => genQueryKey('validate', context)
     };
   }, [context]);
 
@@ -40,11 +39,6 @@ function VariableEditor(props: EditorProps) {
     queryKey: queryKeys.data(),
     queryFn: () => client.data(context),
     structuralSharing: false
-  });
-
-  const { data: knownVariables } = useQuery({
-    queryKey: queryKeys.knownVariables(),
-    queryFn: () => client.meta('meta/knownVariables', context)
   });
 
   useQuery({
@@ -100,11 +94,11 @@ function VariableEditor(props: EditorProps) {
       masterTitle={title}
       masterContent={
         <VariablesMaster
+          context={context}
           variables={rootVariable.children}
           setVariables={setVariables}
           setSelectedVariablePath={setSelectedVariablePath}
           validationMessages={validationMessages}
-          knownVariables={knownVariables}
         />
       }
       detailTitle={detailTitle}

--- a/packages/variable-editor/src/VariableEditor.tsx
+++ b/packages/variable-editor/src/VariableEditor.tsx
@@ -12,6 +12,7 @@ import type { Data, EditorProps, ValidationMessages } from './protocol/types';
 import type { Unary } from './utils/lambda/lambda';
 import { getNode } from './utils/tree/tree-data';
 import type { TreePath } from './utils/tree/types';
+import { genQueryKey } from './query/query-client';
 
 function VariableEditor(props: EditorProps) {
   const [context, setContext] = useState(props.context);
@@ -28,10 +29,10 @@ function VariableEditor(props: EditorProps) {
 
   const queryKeys = useMemo(() => {
     return {
-      data: () => ['variable-editor', 'data', context],
-      saveData: () => ['saveData'],
-      validate: () => ['validate'],
-      knownVariables: () => ['meta/knownVariables']
+      data: () => genQueryKey('data', context),
+      saveData: () => genQueryKey('saveData', context),
+      validate: () => genQueryKey('validate', context),
+      knownVariables: () => genQueryKey('meta/knownVariables', context)
     };
   }, [context]);
 

--- a/packages/variable-editor/src/components/variables/master/OverwriteDialog.tsx
+++ b/packages/variable-editor/src/components/variables/master/OverwriteDialog.tsx
@@ -68,38 +68,21 @@ export const OverwriteDialog = ({ context, table, variables, setVariables, setSe
       };
     }, [context]);
 
-    const { data: knownVariables } = useQuery({
+    const { data: knownVars } = useQuery({
       queryKey: queryKeys.knownVariables(),
       queryFn: () => client.meta('meta/knownVariables', context)
     });
 
+    const [knownVariables, setKnownVariables] = useState<ProjectVarNode>();
+    useEffect(() => {
+      setKnownVariables(knownVars);
+    }, [knownVars]);
+
     const [nodes, setNodes] = useState<BrowserNode[]>([]);
 
-    const toNode = (node: ProjectVarNode): BrowserNode => {
-      const c = node.children.map(child => toNode(child));
-      const icon = nodeIcon(node);
-      const info = node.description;
-      return {
-        value: node.name,
-        info,
-        icon,
-        data: node,
-        children: c
-      };
-    };
-
-    const toNodes = (): Array<BrowserNode> => {
-      if (!knownVariables) {
-        return [];
-      }
-      return knownVariables.children.map(varNode => toNode(varNode));
-    };
-
-    const n = toNodes();
-
     useEffect(() => {
-      setNodes(n);
-    }, [n]);
+      setNodes(toNodes(knownVariables));
+    }, [knownVariables]);
 
     const variableBrowser = useBrowser(nodes);
     return (
@@ -145,7 +128,7 @@ export const OverwriteDialog = ({ context, table, variables, setVariables, setSe
       <DialogTrigger asChild>
         <Button icon={IvyIcons.FileImport} aria-label='Overwrite variable' />
       </DialogTrigger>
-      <DialogContent style={{ height: '40vh', gridTemplateRows: 'auto 1fr auto' }}>
+      <DialogContent style={{ height: '60vh', width: '500px', gridTemplateRows: 'auto 1fr auto' }}>
         <DialogHeader>
           <DialogTitle>Import and overwrite variable from required projects</DialogTitle>
         </DialogHeader>
@@ -159,4 +142,24 @@ export const OverwriteDialog = ({ context, table, variables, setVariables, setSe
       </DialogContent>
     </Dialog>
   );
+};
+
+const toNode = (node: ProjectVarNode): BrowserNode => {
+  const c = node.children.map(child => toNode(child));
+  const icon = nodeIcon(node);
+  const info = node.description;
+  return {
+    value: node.name,
+    info,
+    icon,
+    data: node,
+    children: c
+  };
+};
+
+const toNodes = (root?: ProjectVarNode): Array<BrowserNode> => {
+  if (!root) {
+    return [];
+  }
+  return root.children.map(varNode => toNode(varNode));
 };

--- a/packages/variable-editor/src/components/variables/master/OverwriteDialog.tsx
+++ b/packages/variable-editor/src/components/variables/master/OverwriteDialog.tsx
@@ -10,48 +10,29 @@ import {
   type BrowserNode
 } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
-import { useState, type ReactNode } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { type Table } from '@tanstack/react-table';
-import type { ProjectVarNode } from '../../../protocol/types';
-import { addNode } from '../../../utils/tree/tree-data';
-import { VariableFactory, type Variable } from '../data/variable';
-import { nodeIcon } from '../data/variable-utils';
-import type { TreePath } from '../../../utils/tree/types';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useClient } from '../../../protocol';
+import type { DataContext, ProjectVarNode } from '../../../protocol/types';
+import { genQueryKey } from '../../../query';
 import { selectRow } from '../../../utils/table/table';
 import { toRowId } from '../../../utils/tree/tree';
+import { addNode } from '../../../utils/tree/tree-data';
+import type { TreePath } from '../../../utils/tree/types';
 import { isMetadataType, type MetadataType } from '../data/metadata';
+import { VariableFactory, type Variable } from '../data/variable';
+import { nodeIcon } from '../data/variable-utils';
 
 type OverwriteProps = {
-  knownVariables?: ProjectVarNode;
+  context: DataContext;
   table: Table<Variable>;
   variables: Array<Variable>;
   setVariables: (variables: Array<Variable>) => void;
   setSelectedVariablePath: (path: TreePath) => void;
 };
 
-export const OverwriteDialog = ({ knownVariables, table, variables, setVariables, setSelectedVariablePath }: OverwriteProps) => {
-  const toNode = (node: ProjectVarNode): BrowserNode => {
-    const c = node.children.map(child => toNode(child));
-    const icon = nodeIcon(node);
-    const info = node.description;
-    return {
-      value: node.name,
-      info,
-      icon,
-      data: node,
-      children: c
-    };
-  };
-
-  const toNodes = (): Array<BrowserNode> => {
-    if (!knownVariables) {
-      return [];
-    }
-    return knownVariables.children.map(varNode => toNode(varNode));
-  };
-
-  const nodes = toNodes();
-
+export const OverwriteDialog = ({ context, table, variables, setVariables, setSelectedVariablePath }: OverwriteProps) => {
   const insertVariable = (node?: ProjectVarNode): void => {
     if (node) {
       const lastDot = node?.key.lastIndexOf('.');
@@ -78,7 +59,48 @@ export const OverwriteDialog = ({ knownVariables, table, variables, setVariables
     }
   };
 
-  const VariableBrowser = ({ applyFn }: { applyFn: (node?: ProjectVarNode) => void }) => {
+  const VariableBrowser = ({ applyFn, context }: { applyFn: (node?: ProjectVarNode) => void; context: DataContext }) => {
+    const client = useClient();
+
+    const queryKeys = useMemo(() => {
+      return {
+        knownVariables: () => genQueryKey('meta/knownVariables', context)
+      };
+    }, [context]);
+
+    const { data: knownVariables } = useQuery({
+      queryKey: queryKeys.knownVariables(),
+      queryFn: () => client.meta('meta/knownVariables', context)
+    });
+
+    const [nodes, setNodes] = useState<BrowserNode[]>([]);
+
+    const toNode = (node: ProjectVarNode): BrowserNode => {
+      const c = node.children.map(child => toNode(child));
+      const icon = nodeIcon(node);
+      const info = node.description;
+      return {
+        value: node.name,
+        info,
+        icon,
+        data: node,
+        children: c
+      };
+    };
+
+    const toNodes = (): Array<BrowserNode> => {
+      if (!knownVariables) {
+        return [];
+      }
+      return knownVariables.children.map(varNode => toNode(varNode));
+    };
+
+    const n = toNodes();
+
+    useEffect(() => {
+      setNodes(n);
+    }, [n]);
+
     const variableBrowser = useBrowser(nodes);
     return (
       <BrowsersView
@@ -132,6 +154,7 @@ export const OverwriteDialog = ({ knownVariables, table, variables, setVariables
             insertVariable(node);
             setDialogState(false);
           }}
+          context={context}
         />
       </DialogContent>
     </Dialog>

--- a/packages/variable-editor/src/components/variables/master/OverwriteDialog.tsx
+++ b/packages/variable-editor/src/components/variables/master/OverwriteDialog.tsx
@@ -62,21 +62,12 @@ export const OverwriteDialog = ({ context, table, variables, setVariables, setSe
   const VariableBrowser = ({ applyFn, context }: { applyFn: (node?: ProjectVarNode) => void; context: DataContext }) => {
     const client = useClient();
 
-    const queryKeys = useMemo(() => {
-      return {
-        knownVariables: () => genQueryKey('meta/knownVariables', context)
-      };
-    }, [context]);
+    const queryKeys = useMemo(() => ({ knownVariables: () => genQueryKey('meta/knownVariables', context) }), [context]);
 
-    const { data: knownVars } = useQuery({
+    const { data: knownVariables } = useQuery({
       queryKey: queryKeys.knownVariables(),
       queryFn: () => client.meta('meta/knownVariables', context)
     });
-
-    const [knownVariables, setKnownVariables] = useState<ProjectVarNode>();
-    useEffect(() => {
-      setKnownVariables(knownVars);
-    }, [knownVars]);
 
     const [nodes, setNodes] = useState<BrowserNode[]>([]);
 

--- a/packages/variable-editor/src/components/variables/master/VariablesMaster.tsx
+++ b/packages/variable-editor/src/components/variables/master/VariablesMaster.tsx
@@ -12,7 +12,7 @@ import {
 } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { getCoreRowModel, useReactTable, type ColumnDef } from '@tanstack/react-table';
-import type { ProjectVarNode, ValidationMessages } from '../../../protocol/types';
+import type { DataContext, ValidationMessages } from '../../../protocol/types';
 import { isRowSelected, selectRow } from '../../../utils/table/table';
 import { deleteFirstSelectedRow, useTreeGlobalFilter } from '../../../utils/tree/tree';
 import { treeNodeNameAttribute, type TreePath } from '../../../utils/tree/types';
@@ -21,25 +21,19 @@ import { validationMessagesOfRow } from '../data/validation-utils';
 import { type Variable } from '../data/variable';
 import { variableIcon } from '../data/variable-utils';
 import { AddVariableDialog } from './AddVariableDialog';
+import { OverwriteDialog } from './OverwriteDialog';
 import { ValidationRow } from './ValidationRow';
 import './VariablesMaster.css';
-import { OverwriteDialog } from './OverwriteDialog';
 
 type VariablesProps = {
+  context: DataContext;
   variables: Array<Variable>;
   setVariables: (variables: Array<Variable>) => void;
   setSelectedVariablePath: (path: TreePath) => void;
   validationMessages?: ValidationMessages;
-  knownVariables?: ProjectVarNode;
 };
 
-export const VariablesMaster = ({
-  variables,
-  setVariables,
-  setSelectedVariablePath,
-  validationMessages,
-  knownVariables
-}: VariablesProps) => {
+export const VariablesMaster = ({ context, variables, setVariables, setSelectedVariablePath, validationMessages }: VariablesProps) => {
   const selection = useTableSelect<Variable>();
   const expanded = useTableExpand<Variable>();
   const globalFilter = useTreeGlobalFilter(variables);
@@ -93,7 +87,7 @@ export const VariablesMaster = ({
         setSelectedVariablePath={setSelectedVariablePath}
       />,
       <OverwriteDialog
-        knownVariables={knownVariables}
+        context={context}
         table={table}
         variables={variables}
         setVariables={setVariables}

--- a/packages/variable-editor/src/index.ts
+++ b/packages/variable-editor/src/index.ts
@@ -1,2 +1,3 @@
 export { default as VariableEditor } from './VariableEditor';
 export * from './protocol';
+export * from './query';

--- a/packages/variable-editor/src/protocol/index.ts
+++ b/packages/variable-editor/src/protocol/index.ts
@@ -1,3 +1,2 @@
 export * from './ClientContextProvider';
-export * from './QueryProvider';
 export * from './client-json-rpc';

--- a/packages/variable-editor/src/protocol/types.ts
+++ b/packages/variable-editor/src/protocol/types.ts
@@ -22,7 +22,6 @@ export interface RequestTypes extends MetaRequestTypes {
   data: [any, any];
   saveData: [any, any];
   validate: [any, any];
-  overwritables: [any, any];
 }
 
 export interface NotificationTypes {

--- a/packages/variable-editor/src/query/QueryProvider.tsx
+++ b/packages/variable-editor/src/query/QueryProvider.tsx
@@ -1,10 +1,7 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { QueryClient } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import type { ReactNode } from 'react';
-
-export const initQueryClient = () => {
-  return new QueryClient();
-};
 
 export const QueryProvider = ({ client, children }: { client: QueryClient; children: ReactNode }) => (
   <QueryClientProvider client={client}>

--- a/packages/variable-editor/src/query/index.ts
+++ b/packages/variable-editor/src/query/index.ts
@@ -1,0 +1,2 @@
+export * from './query-client';
+export * from './QueryProvider';

--- a/packages/variable-editor/src/query/query-client.ts
+++ b/packages/variable-editor/src/query/query-client.ts
@@ -1,0 +1,9 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const initQueryClient = () => {
+  return new QueryClient();
+};
+
+export const genQueryKey = (...args: unknown[]) => {
+  return ['variable-editor', ...args];
+};


### PR DESCRIPTION
This addresses most of the comments of this PR https://github.com/axonivy/config-editor-client/pull/142:
1. Add more context to the query key
2. Remove not needed methods ' overwritables'
3. Get the knownVariables if the overwrite dialog is opened instead of when the variable editor is loaded
4. Make the overwrite dialog larger

Will try to import more than one variable if one selects a parent in another PR.