### PR TITLE
XIVY-14795 do not write null for empty values

### DIFF
--- a/packages/variable-editor/src/components/variables/data/test-utils/variables-empty.ts
+++ b/packages/variable-editor/src/components/variables/data/test-utils/variables-empty.ts
@@ -26,3 +26,24 @@ export const rootVariableParsedFromContentWithCommentOnly: RootVariable = {
   metadata: { type: '' },
   children: []
 };
+
+export const contentWithEmptyValue = `Variables:
+  EmptyValue:
+`;
+
+export const rootVariableWithEmptyValue: RootVariable = {
+  name: 'Variables',
+  value: '',
+  description: '',
+  commentAfter: '',
+  metadata: { type: '' },
+  children: [
+    {
+      name: 'EmptyValue',
+      value: '',
+      description: '',
+      metadata: { type: '' },
+      children: []
+    }
+  ]
+};

--- a/packages/variable-editor/src/components/variables/data/variable-utils.test.ts
+++ b/packages/variable-editor/src/components/variables/data/variable-utils.test.ts
@@ -3,10 +3,12 @@ import { content, contentStringsOnly, rootVariable } from './test-utils/variable
 import {
   contentEmpty,
   contentWithCommentOnly,
+  contentWithEmptyValue,
   contentWithEmptyVariables,
   contentWithEmptyVariablesMapping,
   rootVariableEmpty,
-  rootVariableParsedFromContentWithCommentOnly
+  rootVariableParsedFromContentWithCommentOnly,
+  rootVariableWithEmptyValue
 } from './test-utils/variables-empty';
 import { contentNotYAML, contentWithMultipleTopLevelNodes, contentWithWrongNameOfTopLevelNode } from './test-utils/variables-malformed';
 import { contentMixed, rootVariableMixed } from './test-utils/variables-mixed';
@@ -80,6 +82,10 @@ describe('variable-utils', () => {
 
       test('commentOnly', () => {
         expect(toVariables(contentWithCommentOnly)).toEqual(rootVariableParsedFromContentWithCommentOnly);
+      });
+
+      test('emptyValue', () => {
+        expect(toVariables(contentWithEmptyValue)).toEqual(rootVariableWithEmptyValue);
       });
     });
 

--- a/packages/variable-editor/src/components/variables/data/variable-utils.ts
+++ b/packages/variable-editor/src/components/variables/data/variable-utils.ts
@@ -118,7 +118,10 @@ const enrichVariableWithChildren = (variable: Variable, node: Pair<Scalar, YAMLM
 const enrichVariableWithoutChildren = (variable: Variable, node: Pair<Scalar, Scalar>) => {
   const nodeValue = node.value;
   if (nodeValue) {
-    variable.value = String(nodeValue.value);
+    const nodeValueValue = nodeValue.value;
+    if (nodeValueValue !== null) {
+      variable.value = String(nodeValueValue);
+    }
   }
   return enrichVariableDescriptionAndMetadata(variable, node);
 };


### PR DESCRIPTION
Write an empty string (`""`) instead of `"null"` for a previously missing variable value.