### PR TITLE
XIVY-15025 Fix input focus to end jump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,17 +71,17 @@
       "link": true
     },
     "node_modules/@axonivy/jsonrpc": {
-      "version": "12.0.0-next.308",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/jsonrpc/-/jsonrpc-12.0.0-next.308.tgz",
-      "integrity": "sha512-Jh1akkMx/2E1CaCBfPE6mq0vF6Te1fSYtYPiq6sErBkDP8OM/NM+h7qJkVUpjxkHPzkGsWKdubWVJ46K6G9PmA==",
+      "version": "12.0.0-next.318",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/jsonrpc/-/jsonrpc-12.0.0-next.318.tgz",
+      "integrity": "sha512-WWxJ1ZcMeIZ/w+pKd611/IhAovd7PIBL0LGm16sbbfSSW7/YRzpjWxjdaZM9TdjUtBxsTc4QgDBYiTg4B9DulA==",
       "dependencies": {
         "vscode-jsonrpc": "^8.2.0"
       }
     },
     "node_modules/@axonivy/ui-components": {
-      "version": "12.0.0-next.308",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-components/-/ui-components-12.0.0-next.308.tgz",
-      "integrity": "sha512-8WVCBu8/ux9ICb+8nd0d9lpRNC7CLdXCu4fCycgyoRSnHScJ9zrEY9H5L8L01FFFy5o+BMyBMED3LkOtna6I5w==",
+      "version": "12.0.0-next.318",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-components/-/ui-components-12.0.0-next.318.tgz",
+      "integrity": "sha512-TBgdVrqVM1TQ12EBe7EKYA9dT05KDAEKjIIyiJXkIWco1L+k9aZFTa3Fh8WxKBuWjBeGGP/Mkzlnrjzje5VTUA==",
       "dependencies": {
         "@radix-ui/react-accordion": "1.2.0",
         "@radix-ui/react-checkbox": "1.1.1",
@@ -110,9 +110,9 @@
       }
     },
     "node_modules/@axonivy/ui-icons": {
-      "version": "12.0.0-next.308",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-icons/-/ui-icons-12.0.0-next.308.tgz",
-      "integrity": "sha512-QT67nIerB0MU7sOfmJyAKX5LzutRRvRITC3yzqBUF6YFBmrCvVEZ/Zn9to5Udjii2JDCh+aTMUzRbJzwlOfY9Q=="
+      "version": "12.0.0-next.318",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-icons/-/ui-icons-12.0.0-next.318.tgz",
+      "integrity": "sha512-dBKImZPC++I48vO0jIOS2R2gx3V5p/f6wL00Jn8J46T7rjn32ZtqKNokBLohRm0OWdttWJRTe/kC8omYlDD62g=="
     },
     "node_modules/@axonivy/variable-editor": {
       "resolved": "packages/variable-editor",
@@ -15047,9 +15047,9 @@
       "version": "12.0.0-next",
       "license": "Apache-2.0",
       "dependencies": {
-        "@axonivy/jsonrpc": "~12.0.0-next.308",
-        "@axonivy/ui-components": "~12.0.0-next.308",
-        "@axonivy/ui-icons": "~12.0.0-next.308",
+        "@axonivy/jsonrpc": "~12.0.0-next.318",
+        "@axonivy/ui-components": "~12.0.0-next.318",
+        "@axonivy/ui-icons": "~12.0.0-next.318",
         "@tanstack/react-query": "5.32.1",
         "@tanstack/react-query-devtools": "5.32.1",
         "react": "^18.3.1",

--- a/packages/variable-editor/package.json
+++ b/packages/variable-editor/package.json
@@ -17,9 +17,9 @@
   "types": "lib/index.d.ts",
   "main": "lib/editor.js",
   "dependencies": {
-    "@axonivy/jsonrpc": "~12.0.0-next.308",
-    "@axonivy/ui-components": "~12.0.0-next.308",
-    "@axonivy/ui-icons": "~12.0.0-next.308",
+    "@axonivy/jsonrpc": "~12.0.0-next.318",
+    "@axonivy/ui-components": "~12.0.0-next.318",
+    "@axonivy/ui-icons": "~12.0.0-next.318",
     "@tanstack/react-query": "5.32.1",
     "@tanstack/react-query-devtools": "5.32.1",
     "react": "^18.3.1",

--- a/packages/variable-editor/src/components/variables/detail/Value.tsx
+++ b/packages/variable-editor/src/components/variables/detail/Value.tsx
@@ -1,4 +1,4 @@
-import { BasicField, BasicSelect, Input, PasswordInput } from '@axonivy/ui-components';
+import { BasicField, BasicSelect, BasicInput, PasswordInput } from '@axonivy/ui-components';
 import { useMemo } from 'react';
 import { isEnumMetadata } from '../data/metadata';
 import type { Variable, VariableUpdates } from '../data/variable';
@@ -22,7 +22,9 @@ export const Value = ({ variable, onChange }: ValueProps) => {
       case 'password':
         return <PasswordInput value={variable.value} onChange={(newValue: string) => onChange([{ key: 'value', value: newValue }])} />;
       case 'daytime':
-        return <Input value={variable.value} onChange={event => onChange([{ key: 'value', value: event.target.value }])} type='time' />;
+        return (
+          <BasicInput value={variable.value} onChange={event => onChange([{ key: 'value', value: event.target.value }])} type='time' />
+        );
       case 'enum':
         return (
           <BasicSelect
@@ -34,7 +36,7 @@ export const Value = ({ variable, onChange }: ValueProps) => {
         );
       default:
         return (
-          <Input
+          <BasicInput
             value={variable.value}
             onChange={event => onChange([{ key: 'value', value: event.target.value }])}
             autoFocus={variable.value.length === 0}

--- a/packages/variable-editor/src/components/variables/detail/VariablesDetailContent.tsx
+++ b/packages/variable-editor/src/components/variables/detail/VariablesDetailContent.tsx
@@ -1,4 +1,4 @@
-import { BasicField, Flex, Input, PanelMessage, Textarea } from '@axonivy/ui-components';
+import { BasicField, Flex, BasicInput, PanelMessage, Textarea } from '@axonivy/ui-components';
 import { useAppContext } from '../../../context/AppContext';
 import { getNode, updateNode, hasChildren as variableHasChildren } from '../../../utils/tree/tree-data';
 import { type VariableUpdates } from '../data/variable';
@@ -24,7 +24,7 @@ export const VariablesDetailContent = () => {
   return (
     <Flex direction='column' gap={4} className='detail-content'>
       <BasicField label='Name'>
-        <Input value={variable.name} onChange={event => handleVariableAttributeChange([{ key: 'name', value: event.target.value }])} />
+        <BasicInput value={variable.name} onChange={event => handleVariableAttributeChange([{ key: 'name', value: event.target.value }])} />
       </BasicField>
       {!hasChildren && <Value variable={variable} onChange={handleVariableAttributeChange} />}
       <BasicField label='Description'>


### PR DESCRIPTION
Before:
![Screen Recording 2024-09-20 at 08 30 27](https://github.com/user-attachments/assets/81bfec4b-8eef-4e0b-a5a6-72f3da9b1c5b)

After:
![Screen Recording 2024-09-20 at 09 46 22](https://github.com/user-attachments/assets/5f4398ad-8bf6-4961-a65e-cb1261877e0a)


You may ask yourself WTF 🤣 
I was also surprised at the beginning, and I needed some time to find the problem.
The reason is that there are two ways you can write an input field, controlled and uncontrolled:
- controlled: you hold the state -> use the `value` prop
- uncontrolled: the browser holds the state -> use the `defaultValue` prop

So before we used the `value` prop, means we need to hold the state and you may now think we do. I have two assumptions why this is still a problem:
- The reference of the variable changes, so react means there is a new value, and "rerenders to much" of the input so the cursor state forgets where it was
- The parent rerenders and somehow the input losses because of this to much info

And the solution currently for this is:
- Just use the `defaultValue` and let the browser handle the state
- Or hold the state for the input with a useState

As we do not really need to make changes in the UI based on this value state, I made the (in my eyes) the simpler change and just use the `defaultValue` prop, maybe with the "consequence" that we need to change this again in the future, but then also with holding the state for the input field.

PS: by the way this is currently also broken in the dataclass editor, I will provide a fix there too.