### PR TITLE
deselect if clicked anywhere in master content

### DIFF
--- a/packages/variable-editor/src/components/variables/master/VariablesMasterContent.css
+++ b/packages/variable-editor/src/components/variables/master/VariablesMasterContent.css
@@ -2,7 +2,12 @@
   overflow: hidden auto;
 }
 
+.master-content-container {
+  height: 100%;
+}
+
 .master-content {
   margin: var(--size-3);
   min-height: 0;
+  height: fit-content;
 }

--- a/packages/variable-editor/src/components/variables/master/VariablesMasterContent.tsx
+++ b/packages/variable-editor/src/components/variables/master/VariablesMasterContent.tsx
@@ -85,16 +85,18 @@ export const VariablesMasterContent = () => {
   );
 
   return (
-    <BasicField className='master-content' label='List of variables' control={control}>
-      {globalFilter.filter}
-      <Table>
-        <TableResizableHeader headerGroups={table.getHeaderGroups()} onClick={resetSelection} />
-        <TableBody>
-          {table.getRowModel().rows.map(row => (
-            <ValidationRow key={row.id} row={row} />
-          ))}
-        </TableBody>
-      </Table>
-    </BasicField>
+    <Flex direction='column' className='master-content-container' onClick={resetSelection}>
+      <BasicField className='master-content' label='List of variables' control={control} onClick={event => event.stopPropagation()}>
+        {globalFilter.filter}
+        <Table>
+          <TableResizableHeader headerGroups={table.getHeaderGroups()} onClick={resetSelection} />
+          <TableBody>
+            {table.getRowModel().rows.map(row => (
+              <ValidationRow key={row.id} row={row} />
+            ))}
+          </TableBody>
+        </Table>
+      </BasicField>
+    </Flex>
   );
 };


### PR DESCRIPTION
Regarding https://github.com/axonivy/dataclass-editor-client/pull/38
I think I found a better approach while doing the same for the variables editor.
We have an element that triggers the desired `onClick` function and takes the whole space of the master content (`master-content-container`). On the first and only child (`master-content`), we stop the propagation of the event. This way, we don't have to stop it on the rows the control buttons and the search field individually.