### PR TITLE
XIVY-15648 info when manually importing variable

### DIFF
--- a/playwright/tests/integration/mock/editor.spec.ts
+++ b/playwright/tests/integration/mock/editor.spec.ts
@@ -1,6 +1,6 @@
-import { test } from '@playwright/test';
-import { VariableEditor } from '../../pageobjects/VariableEditor';
+import { expect, test } from '@playwright/test';
 import type { Table } from '../../pageobjects/Table';
+import { VariableEditor } from '../../pageobjects/VariableEditor';
 
 let editor: VariableEditor;
 let tree: Table;
@@ -89,7 +89,7 @@ test('add', async () => {
 test('addVariableDialogDefaultValues', async () => {
   await tree.row(5).click();
   await tree.row(5).expectValues(['useUserPassFlow', '']);
-  await editor.add.open();
+  await editor.add.open.click();
   await editor.add.expectValues('NewVariable', 'microsoft-connector.useUserPassFlow', 'microsoft-connector', 'microsoft-connector.useUserPassFlow');
 });
 
@@ -97,48 +97,48 @@ test.describe('addVariableDialogValidation', async () => {
   test.describe('name', async () => {
     test('onNameChange', async () => {
       const add = editor.add;
-      await add.open();
+      await add.open.click();
       await add.nameMessage.expectToBeHidden();
-      await add.expectCreateEnabled();
+      await expect(add.create.locator).toBeEnabled();
       await add.name.fill('');
       await add.nameMessage.expectErrorMessage('Name cannot be empty.');
-      await add.expectCreateDisabled();
+      await expect(add.create.locator).toBeDisabled();
       await add.name.fill('microsoft-connector');
       await add.nameMessage.expectErrorMessage('Name is already present in this Namespace.');
-      await add.expectCreateDisabled();
+      await expect(add.create.locator).toBeDisabled();
     });
 
     test('onNamespaceChange', async () => {
       const add = editor.add;
-      await add.open();
+      await add.open.click();
       await add.name.fill('appId');
       await add.nameMessage.expectToBeHidden();
-      await add.expectCreateEnabled();
+      await expect(add.create.locator).toBeEnabled();
       await add.namespace.choose('microsoft-connector');
       await add.nameMessage.expectErrorMessage('Name is already present in this Namespace.');
-      await add.expectCreateDisabled();
+      await expect(add.create.locator).toBeDisabled();
     });
 
     test('onNamespaceInput', async () => {
       const add = editor.add;
-      await add.open();
+      await add.open.click();
       await add.name.fill('appId');
       await add.nameMessage.expectToBeHidden();
-      await add.expectCreateEnabled();
+      await expect(add.create.locator).toBeEnabled();
       await add.namespace.fill('microsoft-connector');
       await add.nameMessage.expectErrorMessage('Name is already present in this Namespace.');
-      await add.expectCreateDisabled();
+      await expect(add.create.locator).toBeDisabled();
     });
   });
 
   test('namespace', async () => {
     const add = editor.add;
-    await add.open();
+    await add.open.click();
     await add.namespaceMessage.expectInfoMessage("Folder structure of variable (e.g. 'Connector.Key')");
-    await add.expectCreateEnabled();
+    await expect(add.create.locator).toBeEnabled();
     await add.namespace.fill('microsoft-connector.appId.New.Namespace');
     await add.namespaceMessage.expectErrorMessage("Namespace 'microsoft-connector.appId' is not a folder, you cannot add a child to it.");
-    await add.expectCreateDisabled();
+    await expect(add.create.locator).toBeDisabled();
   });
 });
 

--- a/playwright/tests/integration/mock/import.spec.ts
+++ b/playwright/tests/integration/mock/import.spec.ts
@@ -89,7 +89,18 @@ describe('disabledMetadataOfOverwrittenVariable', async () => {
 });
 
 test('import variable when manually adding a known variable', async () => {
-  await editor.addVariable('Comprehend', 'Amazon');
+  await editor.add.open.click();
+  await editor.add.name.fill('Comprehend');
+  await editor.add.namespace.fill('Amazon');
+
+  await expect(editor.add.footerMessage).toBeHidden();
+
+  await editor.add.create.click();
+
+  await expect(editor.add.footerMessage).toBeVisible();
+
+  await editor.add.create.click();
+
   await editor.details.expectFolderValues('Comprehend', 'Amazon comprehend connector settings');
   await editor.tree.expectRowCount(15);
   await editor.tree.row(11).click();

--- a/playwright/tests/pageobjects/AddVariableDialog.ts
+++ b/playwright/tests/pageobjects/AddVariableDialog.ts
@@ -5,41 +5,27 @@ import { FieldMessage } from './FieldMessage';
 import { TextArea } from './TextArea';
 
 export class AddVariableDialog {
-  private readonly add: Button;
+  readonly open: Button;
   readonly name: TextArea;
   readonly nameMessage: FieldMessage;
   readonly namespace: Combobox;
   readonly namespaceMessage: FieldMessage;
-  private readonly create: Button;
+  readonly footerMessage: Locator;
+  readonly create: Button;
 
   constructor(page: Page, parent: Locator) {
-    this.add = new Button(parent, { name: 'Add variable' });
+    this.open = new Button(parent, { name: 'Add variable' });
     this.name = new TextArea(parent);
     this.nameMessage = new FieldMessage(parent, { label: 'Name' });
     this.namespace = new Combobox(page, parent);
     this.namespaceMessage = new FieldMessage(parent, { label: 'Namespace' });
+    this.footerMessage = parent.locator('.ui-dialog-footer').locator('.ui-message');
     this.create = new Button(parent, { name: 'Create variable' });
-  }
-
-  async open() {
-    await this.add.click();
   }
 
   async expectValues(name: string, namespaceValue: string, ...namespaceOptions: Array<string>) {
     await this.name.expectValue(name);
     await this.namespace.expectValue(namespaceValue);
     await this.namespace.expectOptions(...namespaceOptions);
-  }
-
-  async createVariable() {
-    await this.create.click();
-  }
-
-  async expectCreateEnabled() {
-    await this.create.expectEnabled();
-  }
-
-  async expectCreateDisabled() {
-    await this.create.expectDisabled();
   }
 }

--- a/playwright/tests/pageobjects/Button.ts
+++ b/playwright/tests/pageobjects/Button.ts
@@ -1,7 +1,7 @@
 import { expect, type Locator } from '@playwright/test';
 
 export class Button {
-  private readonly locator: Locator;
+  readonly locator: Locator;
 
   constructor(parentLocator: Locator, options?: { name?: string; nth?: number }) {
     if (options?.name) {

--- a/playwright/tests/pageobjects/VariableEditor.ts
+++ b/playwright/tests/pageobjects/VariableEditor.ts
@@ -2,10 +2,10 @@ import { expect, type Locator, type Page } from '@playwright/test';
 import { AddVariableDialog } from './AddVariableDialog';
 import { Button } from './Button';
 import { Details } from './Details';
+import { OverwriteDialog } from './OverwriteDialog';
 import { Settings } from './Settings';
 import { Table } from './Table';
 import { TextArea } from './TextArea';
-import { OverwriteDialog } from './OverwriteDialog';
 
 export class VariableEditor {
   readonly page: Page;
@@ -69,13 +69,13 @@ export class VariableEditor {
   }
 
   async addVariable(name?: string, namespace?: string) {
-    await this.add.open();
+    await this.add.open.click();
     if (name) {
       await this.add.name.fill(name);
     }
     if (namespace) {
       await this.add.namespace.fill(namespace);
     }
-    await this.add.createVariable();
+    await this.add.create.click();
   }
 }


### PR DESCRIPTION
An info is shown when trying to manually add a variable that already exists in a required project that it can be imported. Pressing the button again will import the variable.

Also removed some unnecessary pageobject functions.

![overwrite-info](https://github.com/user-attachments/assets/c50084f2-8d2d-4fbc-8a37-1a285489cecd)
