### PR TITLE
Add Navigation via ArrowKey in Main-Table

### DIFF
--- a/integrations/standalone/package.json
+++ b/integrations/standalone/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "version": "13.1.0-next",
   "dependencies": {
-    "@axonivy/ui-components": "~13.1.0-next.417",
-    "@axonivy/ui-icons": "~13.1.0-next.417",
+    "@axonivy/ui-components": "~13.1.0-next.429",
+    "@axonivy/ui-icons": "~13.1.0-next.429",
     "@axonivy/variable-editor": "*",
     "@axonivy/variable-editor-protocol": "*",
     "react": "^18.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "playwright"
       ],
       "devDependencies": {
-        "@axonivy/eslint-config": "~13.1.0-next.417",
+        "@axonivy/eslint-config": "~13.1.0-next.429",
         "@types/node": "^22.10.2",
         "concurrently": "^9.1.0",
         "lerna": "^8.1.9",
@@ -27,8 +27,8 @@
       "name": "@axonivy/config-editor-standalone",
       "version": "13.1.0-next",
       "dependencies": {
-        "@axonivy/ui-components": "~13.1.0-next.417",
-        "@axonivy/ui-icons": "~13.1.0-next.417",
+        "@axonivy/ui-components": "~13.1.0-next.429",
+        "@axonivy/ui-icons": "~13.1.0-next.429",
         "@axonivy/variable-editor": "*",
         "@axonivy/variable-editor-protocol": "*",
         "react": "^18.3.1",
@@ -72,11 +72,10 @@
       "link": true
     },
     "node_modules/@axonivy/eslint-config": {
-      "version": "13.1.0-next.417",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/eslint-config/-/eslint-config-13.1.0-next.417.tgz",
-      "integrity": "sha512-x+1dXU+JL2ukwSxqvY2Squ1EdSmAWK8t0mjoKGXJDdxF7qlHTSrxsI+kuYfAv8m/Sdt5YnliZvfrPhyKAfU0mw==",
+      "version": "13.1.0-next.429",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/eslint-config/-/eslint-config-13.1.0-next.429.tgz",
+      "integrity": "sha512-vtYjv9QMBrMBpRe8gtGmJZvkwXmCWTLJNbgHOfvdM8rc3T3Xxirn7Jld4Idx+EK0STtel1XJdAt+pTD+LTn6CA==",
       "dev": true,
-      "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
       "dependencies": {
         "@eslint/js": "^9.17.0",
         "@tanstack/eslint-plugin-query": "^5.62.9",
@@ -93,19 +92,17 @@
       }
     },
     "node_modules/@axonivy/jsonrpc": {
-      "version": "13.1.0-next.417",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/jsonrpc/-/jsonrpc-13.1.0-next.417.tgz",
-      "integrity": "sha512-YayKIyVDIi6Y3g4gtcJQlcpgsI4cE1BxlcktdQ9qRVJNmkqw2JSXAjtYqLXiQ/dDW1qeHOk8NmYqt2lMLGJvyg==",
-      "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
+      "version": "13.1.0-next.429",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/jsonrpc/-/jsonrpc-13.1.0-next.429.tgz",
+      "integrity": "sha512-sszJmzkJcnBTvND0LwA+c1L+P8W5ci0/VWCwY2uCdzBmF3QBw0ojEbjoU8hbtxbzSyTLLnqnpYFcpmOLpqUwXQ==",
       "dependencies": {
         "vscode-jsonrpc": "^8.2.0"
       }
     },
     "node_modules/@axonivy/ui-components": {
-      "version": "13.1.0-next.417",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-components/-/ui-components-13.1.0-next.417.tgz",
-      "integrity": "sha512-R+iHSX1maEVCVzeW8GiurVQRAq/0Orozt7zwNoLr7nZgrzRToDKDk2rOYWvup8IYk/Dr3ZuHyzdXBUa02i9jAQ==",
-      "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
+      "version": "13.1.0-next.429",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-components/-/ui-components-13.1.0-next.429.tgz",
+      "integrity": "sha512-kY/UuFAgWHmb6aDN1xGdxAL/KGB+nrRNfpt/uGp1T/2gcq2ZFTlc5h6zUxP+tC9/z15sWSKquKtpqWZzF9iUeQ==",
       "dependencies": {
         "@radix-ui/react-accordion": "1.2.1",
         "@radix-ui/react-checkbox": "1.1.2",
@@ -125,6 +122,7 @@
         "@tanstack/react-table": "8.20.5",
         "clsx": "2.1.1",
         "downshift": "9.0.8",
+        "react-hotkeys-hook": "^4.6.1",
         "react-resizable-panels": "2.1.7",
         "sonner": "1.7.1"
       },
@@ -133,11 +131,19 @@
         "react": "^18.2 || ^19.0"
       }
     },
+    "node_modules/@axonivy/ui-components/node_modules/react-hotkeys-hook": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-4.6.1.tgz",
+      "integrity": "sha512-XlZpbKUj9tkfgPgT9gA+1p7Ey6vFIZHttUjPqpTdyT5nqQ8mHL7elxvSbaC+dpSiHUSmr21Ya1mDxBZG3aje4Q==",
+      "peerDependencies": {
+        "react": ">=16.8.1",
+        "react-dom": ">=16.8.1"
+      }
+    },
     "node_modules/@axonivy/ui-icons": {
-      "version": "13.1.0-next.417",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-icons/-/ui-icons-13.1.0-next.417.tgz",
-      "integrity": "sha512-n5/VEsUcI43wg4jZhOXJ3/Cultq3D/1bleHPVFCJAhq0vIPPpfT9TMRkR+fYhBezt7oWlcRF7KR7b2n8S5tkXA==",
-      "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)"
+      "version": "13.1.0-next.429",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-icons/-/ui-icons-13.1.0-next.429.tgz",
+      "integrity": "sha512-Dxm9x4WwdPXoVkEriSfa4QwZvjXsz9dPkfQ1tDdxph2BXRhsdQyB9rof8MbrcsSHmWA7UXg+DBWrDYj/Y1qY/Q=="
     },
     "node_modules/@axonivy/variable-editor": {
       "resolved": "packages/variable-editor",
@@ -16116,9 +16122,9 @@
       "version": "13.1.0-next",
       "license": "Apache-2.0",
       "dependencies": {
-        "@axonivy/jsonrpc": "~13.1.0-next.417",
-        "@axonivy/ui-components": "~13.1.0-next.417",
-        "@axonivy/ui-icons": "~13.1.0-next.417",
+        "@axonivy/jsonrpc": "~13.1.0-next.429",
+        "@axonivy/ui-components": "~13.1.0-next.429",
+        "@axonivy/ui-icons": "~13.1.0-next.429",
         "@axonivy/variable-editor-protocol": "~13.1.0-next",
         "@tanstack/react-query": "5.32.1",
         "@tanstack/react-query-devtools": "5.32.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "publish:next": "lerna publish --exact --canary --preid next --pre-dist-tag next --no-git-tag-version --no-push --ignore-scripts --yes"
   },
   "devDependencies": {
-    "@axonivy/eslint-config": "~13.1.0-next.417",
+    "@axonivy/eslint-config": "~13.1.0-next.429",
     "@types/node": "^22.10.2",
     "concurrently": "^9.1.0",
     "lerna": "^8.1.9",

--- a/packages/variable-editor/package.json
+++ b/packages/variable-editor/package.json
@@ -17,9 +17,9 @@
   "types": "lib/index.d.ts",
   "main": "lib/editor.js",
   "dependencies": {
-    "@axonivy/jsonrpc": "~13.1.0-next.417",
-    "@axonivy/ui-components": "~13.1.0-next.417",
-    "@axonivy/ui-icons": "~13.1.0-next.417",
+    "@axonivy/jsonrpc": "~13.1.0-next.429",
+    "@axonivy/ui-components": "~13.1.0-next.429",
+    "@axonivy/ui-icons": "~13.1.0-next.429",
     "@axonivy/variable-editor-protocol": "~13.1.0-next",
     "@tanstack/react-query": "5.32.1",
     "@tanstack/react-query-devtools": "5.32.1",

--- a/packages/variable-editor/src/components/variables/master/ValidationRow.tsx
+++ b/packages/variable-editor/src/components/variables/master/ValidationRow.tsx
@@ -1,9 +1,8 @@
 import { MessageRow, SelectRow, TableCell } from '@axonivy/ui-components';
 import type { Severity, ValidationMessages } from '@axonivy/variable-editor-protocol';
 import { flexRender, type Row } from '@tanstack/react-table';
-import { useAppContext } from '../../../context/AppContext';
 import { useValidations } from '../../../context/useValidation';
-import { getPathOfRow, toTreePath } from '../../../utils/tree/tree';
+import { toTreePath } from '../../../utils/tree/tree';
 import type { Variable } from '../data/variable';
 import './ValidationRow.css';
 
@@ -12,11 +11,10 @@ type ValidationRowProps = {
 };
 
 export const ValidationRow = ({ row }: ValidationRowProps) => {
-  const { setSelectedVariable } = useAppContext();
   const validations = useValidations(toTreePath(row.id));
   return (
     <>
-      <SelectRow row={row} onClick={() => setSelectedVariable(getPathOfRow(row))} className={rowClass(validations)}>
+      <SelectRow row={row} className={rowClass(validations)}>
         {row.getVisibleCells().map(cell => (
           <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
         ))}

--- a/packages/variable-editor/src/utils/tree/tree.ts
+++ b/packages/variable-editor/src/utils/tree/tree.ts
@@ -57,7 +57,7 @@ const adjustSelectionAfterDeletionOfRow = <TNode extends TreeNode<TNode>>(data: 
   return selectedRowPath;
 };
 
-export const toTreePath = (rowId: string) => {
+export const toTreePath = (rowId: string | undefined) => {
   if (!rowId) {
     return [];
   }

--- a/playwright/tests/integration/mock/editor.spec.ts
+++ b/playwright/tests/integration/mock/editor.spec.ts
@@ -146,6 +146,45 @@ test.describe('addVariableDialogValidation', () => {
   });
 });
 
+test.describe('table keyboard support', () => {
+  test('move single selection via arrowKey', async () => {
+    await editor.tree.expectToHaveNothingSelected();
+    await editor.tree.locator.focus();
+    await editor.page.keyboard.press('ArrowDown');
+    await editor.page.keyboard.press('ArrowDown');
+    await editor.tree.expectToBeSelected(1);
+    await editor.page.keyboard.press('ArrowUp');
+    await editor.page.keyboard.press('ArrowUp');
+    await editor.page.keyboard.press('ArrowUp');
+    await editor.tree.expectToBeSelected(9);
+  });
+
+  test('open/close children via arrowKey', async () => {
+    await editor.tree.expectToHaveNothingSelected();
+    await editor.tree.locator.focus();
+    await editor.page.keyboard.press('ArrowDown');
+    await editor.tree.expectRowCount(11);
+    await editor.page.keyboard.press('ArrowLeft');
+    await editor.tree.expectRowCount(1);
+    await editor.page.keyboard.press('ArrowRight');
+    await editor.tree.expectRowCount(11);
+  });
+
+  test('open/close detail via enter', async () => {
+    await editor.tree.expectToHaveNothingSelected();
+    await expect(editor.details.locator).toBeVisible();
+    await editor.tree.locator.focus();
+    await editor.page.keyboard.press('ArrowDown');
+    await editor.page.keyboard.press('Enter');
+    await expect(editor.details.locator).toBeHidden();
+    await editor.page.keyboard.press('ArrowDown');
+    await editor.page.keyboard.press('ArrowDown');
+    await editor.page.keyboard.press('Enter');
+    await expect(editor.details.locator).toBeVisible();
+    await editor.details.expectTitle('Variables - project-name - secretKey');
+  });
+});
+
 test('collapse', async () => {
   const row = tree.row(5);
   await row.expectExpanded();

--- a/playwright/tests/pageobjects/Table.ts
+++ b/playwright/tests/pageobjects/Table.ts
@@ -4,14 +4,14 @@ import { Button } from './Button';
 import { Message } from './Message';
 
 export class Table {
+  readonly locator: Locator;
   private readonly rows: Locator;
   private readonly header: Locator;
-  private readonly locator: Locator;
   readonly messages: Locator;
 
   constructor(readonly page: Page, parentLocator: Locator, readonly columns: ColumnType[], label?: string) {
     if (label === undefined) {
-      this.locator = parentLocator;
+      this.locator = parentLocator.locator('table');
     } else {
       this.locator = parentLocator.getByLabel(label);
     }
@@ -38,6 +38,17 @@ export class Table {
 
   async expectRowCount(rows: number) {
     await expect(this.rows).toHaveCount(rows);
+  }
+
+  async expectToBeSelected(...indexes: Array<number>) {
+    for (let i = 0; i < indexes.length; i++) {
+      await this.row(indexes[i]).expectSelected();
+    }
+  }
+  async expectToHaveNothingSelected() {
+    for (let i = 0; i < (await this.rows.count()); i++) {
+      await this.row(i).expectNotSelected();
+    }
   }
 
   async rowCount() {


### PR DESCRIPTION
I have added enhanced keyboard support for the main table in the Variable Editor. You can now perform the following actions:
- Navigate through rows using the arrow up/down keys.
- Expand or collapse child rows using the arrow right/left keys.
- Open the inscription view for a selected row by pressing Enter.

![keyBoardSupportVariableEditor](https://github.com/user-attachments/assets/7f2a1776-732f-418a-85e0-3c7a4bf06285)
