### PR TITLE
Disable renovate on R12 branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "baseBranches": ["master", "/^release\\/.*/"]
+  "extends": ["config:recommended"],
+  "baseBranches": ["master"]
 }


### PR DESCRIPTION
I vote for first only on master until we have a setting which we want for R12.
- Currently renovate also creates PR's for major update etc. which I'm not sure is the right thing for LTS12...
- Also should we first know how we can disable it for some dependencies etc.