### PR TITLE
remove horizontal scrollbar in pro designer > master

### DIFF
--- a/packages/variable-editor/src/components/variables/master/VariablesMasterContent.css
+++ b/packages/variable-editor/src/components/variables/master/VariablesMasterContent.css
@@ -1,7 +1,3 @@
-.ui-table-root {
-  overflow: hidden auto;
-}
-
 .master-content-container {
   height: 100%;
   overflow: auto;

--- a/packages/variable-editor/src/components/variables/master/VariablesMasterContent.tsx
+++ b/packages/variable-editor/src/components/variables/master/VariablesMasterContent.tsx
@@ -17,7 +17,9 @@ import {
 } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { getCoreRowModel, useReactTable, type ColumnDef } from '@tanstack/react-table';
+import { useRef } from 'react';
 import { useAppContext } from '../../../context/AppContext';
+import { useKnownHotkeys } from '../../../utils/hotkeys';
 import { deleteFirstSelectedRow, toTreePath, useTreeGlobalFilter } from '../../../utils/tree/tree';
 import { type Variable } from '../data/variable';
 import { variableIcon } from '../data/variable-utils';
@@ -25,8 +27,6 @@ import { AddVariableDialog } from '../dialog/AddDialog';
 import { OverwriteDialog } from '../dialog/OverwriteDialog';
 import { ValidationRow } from './ValidationRow';
 import './VariablesMasterContent.css';
-import { useKnownHotkeys } from '../../../utils/hotkeys';
-import { useRef } from 'react';
 
 export const VariablesMasterContent = () => {
   const { variables, setVariables, setSelectedVariable, detail, setDetail } = useAppContext();
@@ -114,7 +114,7 @@ export const VariablesMasterContent = () => {
         onClick={event => event.stopPropagation()}
       >
         {globalFilter.filter}
-        <Table onKeyDown={e => handleKeyDown(e, () => setDetail(!detail))}>
+        <Table onKeyDown={e => handleKeyDown(e, () => setDetail(!detail))} style={{ overflowX: 'unset' }}>
           <TableResizableHeader headerGroups={table.getHeaderGroups()} onClick={resetSelection} />
           <TableBody>
             {table.getRowModel().rows.map(row => (


### PR DESCRIPTION
When a validation message is present, a border is drawn around the respective table row.
In the Pro Designer, this makes a horizontal scrollbar appear on the table, because the border makes the table no longer fit in its container.
This does not happen in Neo or when running the Editor standalone.
I don't understand why this discrepancy exists, but unsetting `overflow-x` on the table makes the scrollbar no longer appear.
However, the border on the right side will not be visible as it does not fit in the container as mentioned above.
No visual change is made to the Neo integration or the standalone Editor.
