### PR TITLE
Use shared preset for renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "baseBranches": ["master"],
-  "rangeStrategy": "in-range-only",
-  "labels": ["dependencies"],
-  "packageRules": [
-    {
-      "matchBaseBranches": ["master"],
-      "matchPackageNames": ["@axonivy/*"],
-      "enabled": false
-    }
-  ]
+  "extends": ["local>axonivy/renovate-config:npm"]  
 }


### PR DESCRIPTION
Will use shared config:
https://github.com/axonivy/renovate-config/blob/master/npm.json

- Labels are added in shared preset
- Activating updates on all release branches, but prevent major updates on release branches
- Prevent updating axonivy packages is already defined in shared preset