### PR TITLE
XIVY-14462 add row virtualization > 12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4509,6 +4509,23 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.12.0.tgz",
+      "integrity": "sha512-6krceiPN07kpxXmU6m8AY7EL0X1gHLu8m3nJdh4phvktzVNxkQfBmSwnRUpoUjGQO1PAn8wSAhYaL8hY1cS1vw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.12.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@tanstack/table-core": {
       "version": "8.20.5",
       "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.20.5.tgz",
@@ -4517,6 +4534,16 @@
       "engines": {
         "node": ">=12"
       },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.12.0.tgz",
+      "integrity": "sha512-7mDINtua3v/pOnn6WUmuT9dPXYSO7WidFej7JzoAfqEOcbbpt/iZ1WPqd+eg+FnrL9nUJK8radqj4iAU51Zchg==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -16049,6 +16076,7 @@
         "@axonivy/variable-editor-protocol": "~12.0.4-next",
         "@tanstack/react-query": "5.32.1",
         "@tanstack/react-query-devtools": "5.32.1",
+        "@tanstack/react-virtual": "^3.12.0",
         "yaml": "^2.7.0"
       },
       "devDependencies": {

--- a/packages/variable-editor/package.json
+++ b/packages/variable-editor/package.json
@@ -23,6 +23,7 @@
     "@axonivy/variable-editor-protocol": "~12.0.4-next",
     "@tanstack/react-query": "5.32.1",
     "@tanstack/react-query-devtools": "5.32.1",
+    "@tanstack/react-virtual": "^3.12.0",
     "yaml": "^2.7.0"
   },
   "peerDependencies": {

--- a/packages/variable-editor/src/components/variables/master/ValidationRow.css
+++ b/packages/variable-editor/src/components/variables/master/ValidationRow.css
@@ -1,12 +1,8 @@
 .ui-table-row.row-error {
   border: 1px solid var(--error-color);
+  width: calc(100% - 2px);
 }
 .ui-table-row.row-warning {
   border: 1px solid var(--warning-color);
-}
-.ui-table-row:has(+ .ui-table-row.row-error) {
-  border-bottom: 1px solid var(--error-color);
-}
-.ui-table-row:has(+ .ui-table-row.row-warning) {
-  border-bottom: 1px solid var(--warning-color);
+  width: calc(100% - 2px);
 }

--- a/packages/variable-editor/src/components/variables/master/ValidationRow.tsx
+++ b/packages/variable-editor/src/components/variables/master/ValidationRow.tsx
@@ -1,22 +1,36 @@
 import { MessageRow, SelectRow, TableCell } from '@axonivy/ui-components';
 import type { Severity, ValidationMessages } from '@axonivy/variable-editor-protocol';
 import { flexRender, type Row } from '@tanstack/react-table';
+import type { VirtualItem, Virtualizer } from '@tanstack/react-virtual';
 import { useValidations } from '../../../context/useValidation';
 import { toTreePath } from '../../../utils/tree/tree';
 import type { Variable } from '../data/variable';
 import './ValidationRow.css';
+import { ROW_HEIGHT } from './VariablesMasterContent';
 
 type ValidationRowProps = {
   row: Row<Variable>;
+  virtualRow: VirtualItem;
+  virtualizer: Virtualizer<HTMLDivElement, HTMLTableRowElement>;
 };
 
-export const ValidationRow = ({ row }: ValidationRowProps) => {
+export const ValidationRow = ({ row, virtualRow, virtualizer }: ValidationRowProps) => {
   const validations = useValidations(toTreePath(row.id));
   return (
     <>
-      <SelectRow row={row} className={rowClass(validations)}>
+      <SelectRow
+        row={row}
+        className={rowClass(validations)}
+        data-index={virtualRow.index}
+        ref={virtualizer.measureElement}
+        style={{
+          transform: `translateY(${virtualRow.start}px)`
+        }}
+      >
         {row.getVisibleCells().map(cell => (
-          <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+          <TableCell key={cell.id} style={{ width: cell.column.getSize() }}>
+            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+          </TableCell>
         ))}
       </SelectRow>
       {validations
@@ -26,6 +40,9 @@ export const ValidationRow = ({ row }: ValidationRowProps) => {
             key={index}
             columnCount={2}
             message={{ message: val.message, variant: val.severity.toLocaleLowerCase() as Lowercase<Severity> }}
+            style={{
+              transform: `translateY(${virtualRow.start + ROW_HEIGHT * (index + 1)}px)`
+            }}
           />
         ))}
     </>

--- a/packages/variable-editor/src/components/variables/master/VariablesMasterContent.css
+++ b/packages/variable-editor/src/components/variables/master/VariablesMasterContent.css
@@ -1,10 +1,42 @@
 .master-content-container {
-  height: 100%;
   overflow: auto;
 }
 
 .master-content {
   margin: var(--size-3);
   min-height: 0;
-  height: fit-content;
+}
+
+.virtual-table-container {
+  overflow-x: hidden;
+  position: relative;
+}
+
+.virtual-table-body tr {
+  display: flex;
+  position: absolute;
+  width: 100%;
+  height: 36px;
+  box-sizing: border-box;
+}
+
+.virtual-table-body td {
+  align-content: center;
+}
+
+.virtual-table-body span,
+.virtual-table-body p {
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Because 'display' is set to 'block' instead of 'flex' on the parent 'p' to
+   make 'text-overflow: ellipsis' work, we need to manually style the icon in
+   the message rows */
+.virtual-table-body p i {
+  padding-right: var(--size-1);
+  vertical-align: middle;
+  line-height: inherit;
 }

--- a/packages/variable-editor/src/components/variables/master/VariablesMasterContent.tsx
+++ b/packages/variable-editor/src/components/variables/master/VariablesMasterContent.tsx
@@ -21,6 +21,7 @@ import {
 } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { getCoreRowModel, useReactTable, type ColumnDef } from '@tanstack/react-table';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { useRef } from 'react';
 import { useAppContext } from '../../../context/AppContext';
 import { useKnownHotkeys } from '../../../utils/hotkeys';
@@ -31,6 +32,8 @@ import { AddVariableDialog } from '../dialog/AddDialog';
 import { OverwriteDialog } from '../dialog/OverwriteDialog';
 import { ValidationRow } from './ValidationRow';
 import './VariablesMasterContent.css';
+
+export const ROW_HEIGHT = 36 as const;
 
 export const VariablesMasterContent = () => {
   const { variables, setVariables, setSelectedVariable, detail, setDetail } = useAppContext();
@@ -48,13 +51,22 @@ export const VariablesMasterContent = () => {
     {
       accessorKey: 'name',
       header: header => <ExpandableHeader name='Name' header={header} />,
-      cell: cell => <ExpandableCell cell={cell} icon={variableIcon(cell.row.original)} />,
-      minSize: 50
+      cell: cell => (
+        <ExpandableCell cell={cell} icon={variableIcon(cell.row.original)}>
+          <span>{cell.getValue()}</span>
+        </ExpandableCell>
+      ),
+      minSize: 200,
+      size: 500,
+      maxSize: 1000
     },
     {
       accessorFn: (variable: Variable) => (variable.metadata.type === 'password' ? '***' : variable.value),
       header: 'Value',
-      cell: cell => <div>{cell.getValue()}</div>
+      cell: cell => <span>{cell.getValue()}</span>,
+      minSize: 200,
+      size: 500,
+      maxSize: 1000
     }
   ];
   const table = useReactTable({
@@ -69,6 +81,25 @@ export const VariablesMasterContent = () => {
       ...expanded.tableState,
       ...globalFilter.tableState
     }
+  });
+
+  const rows = table.getRowModel().rows;
+  const tableContainer = useRef<HTMLDivElement>(null);
+  const measureElement = (element: HTMLTableRowElement) => {
+    let height = ROW_HEIGHT;
+    let nextElement = element.nextElementSibling;
+    while (nextElement?.classList.contains('ui-message-row')) {
+      height += ROW_HEIGHT;
+      nextElement = nextElement.nextElementSibling;
+    }
+    return height;
+  };
+  const virtualizer = useVirtualizer<HTMLDivElement, HTMLTableRowElement>({
+    count: rows.length,
+    estimateSize: () => ROW_HEIGHT,
+    measureElement,
+    getScrollElement: () => tableContainer.current,
+    overscan: 20
   });
 
   const { handleKeyDown } = useTableKeyHandler({
@@ -124,14 +155,17 @@ export const VariablesMasterContent = () => {
         onClick={event => event.stopPropagation()}
       >
         {globalFilter.filter}
-        <Table onKeyDown={e => handleKeyDown(e, () => setDetail(!detail))} style={{ overflowX: 'unset' }}>
-          <TableResizableHeader headerGroups={table.getHeaderGroups()} onClick={resetSelection} />
-          <TableBody>
-            {table.getRowModel().rows.map(row => (
-              <ValidationRow key={row.id} row={row} />
-            ))}
-          </TableBody>
-        </Table>
+        <div ref={tableContainer} className='virtual-table-container'>
+          <Table onKeyDown={e => handleKeyDown(e, () => setDetail(!detail))} style={{ display: 'grid' }}>
+            <TableResizableHeader headerGroups={table.getHeaderGroups()} onClick={resetSelection} />
+            <TableBody style={{ height: `${virtualizer.getTotalSize()}px` }} className='virtual-table-body'>
+              {virtualizer.getVirtualItems().map(virtualRow => {
+                const row = rows[virtualRow.index];
+                return <ValidationRow key={row.id} row={row} virtualRow={virtualRow} virtualizer={virtualizer} />;
+              })}
+            </TableBody>
+          </Table>
+        </div>
       </BasicField>
     </Flex>
   );


### PR DESCRIPTION
- Virtualize rows to improve performance.
- Hard code row height to `36px`.
- Set specific values for sizes in the column defintion because the new layout requires it.
- Fix right side of border on rows with messages not being visible.

Existing problems:
- Did not manage to make table header sticky.
- Because of the new layout, the columns are not automatically using all the available space.
  This means that the rightmost column will be cut off even though there seems to be more space available.
  And because of our implementation of `TableResizableHeader`, the rightmost row is currently not resizable.
