### PR TITLE
XIVY-16068 improve virtual row height calculation > 12

### DIFF
--- a/packages/variable-editor/src/components/variables/data/variable.ts
+++ b/packages/variable-editor/src/components/variables/data/variable.ts
@@ -1,9 +1,11 @@
+import type { ValidationMessages } from '@axonivy/variable-editor-protocol';
 import type { TreeNode, TreeNodeFactory, TreeNodeUpdate, TreeNodeUpdates } from '../../../utils/tree/types';
 import type { Metadata } from './metadata';
 
 export interface Variable extends TreeNode<Variable> {
   description: string;
   metadata: Metadata;
+  validations?: ValidationMessages;
 }
 export const createVariable: TreeNodeFactory<Variable> = (name: string) => ({
   name: name,

--- a/packages/variable-editor/src/components/variables/master/ValidationRow.tsx
+++ b/packages/variable-editor/src/components/variables/master/ValidationRow.tsx
@@ -1,9 +1,7 @@
 import { MessageRow, SelectRow, TableCell } from '@axonivy/ui-components';
 import type { Severity, ValidationMessages } from '@axonivy/variable-editor-protocol';
 import { flexRender, type Row } from '@tanstack/react-table';
-import type { VirtualItem, Virtualizer } from '@tanstack/react-virtual';
-import { useValidations } from '../../../context/useValidation';
-import { toTreePath } from '../../../utils/tree/tree';
+import type { VirtualItem } from '@tanstack/react-virtual';
 import type { Variable } from '../data/variable';
 import './ValidationRow.css';
 import { ROW_HEIGHT } from './VariablesMasterContent';
@@ -11,18 +9,14 @@ import { ROW_HEIGHT } from './VariablesMasterContent';
 type ValidationRowProps = {
   row: Row<Variable>;
   virtualRow: VirtualItem;
-  virtualizer: Virtualizer<HTMLDivElement, HTMLTableRowElement>;
 };
 
-export const ValidationRow = ({ row, virtualRow, virtualizer }: ValidationRowProps) => {
-  const validations = useValidations(toTreePath(row.id));
+export const ValidationRow = ({ row, virtualRow }: ValidationRowProps) => {
   return (
     <>
       <SelectRow
         row={row}
-        className={rowClass(validations)}
-        data-index={virtualRow.index}
-        ref={virtualizer.measureElement}
+        className={rowClass(row.original.validations)}
         style={{
           transform: `translateY(${virtualRow.start}px)`
         }}
@@ -33,27 +27,31 @@ export const ValidationRow = ({ row, virtualRow, virtualizer }: ValidationRowPro
           </TableCell>
         ))}
       </SelectRow>
-      {validations
-        .filter(val => val.severity !== 'INFO')
-        .map((val, index) => (
-          <MessageRow
-            key={index}
-            columnCount={2}
-            message={{ message: val.message, variant: val.severity.toLocaleLowerCase() as Lowercase<Severity> }}
-            style={{
-              transform: `translateY(${virtualRow.start + ROW_HEIGHT * (index + 1)}px)`
-            }}
-          />
-        ))}
+      {row.original.validations &&
+        row.original.validations
+          .filter(val => val.severity !== 'INFO')
+          .map((val, index) => (
+            <MessageRow
+              key={index}
+              columnCount={2}
+              message={{ message: val.message, variant: val.severity.toLocaleLowerCase() as Lowercase<Severity> }}
+              style={{
+                transform: `translateY(${virtualRow.start + ROW_HEIGHT * (index + 1)}px)`
+              }}
+            />
+          ))}
     </>
   );
 };
 
-export const rowClass = (messages: ValidationMessages) => {
-  if (messages.find(message => message.severity === 'ERROR')) {
+export const rowClass = (validations?: ValidationMessages) => {
+  if (!validations) {
+    return '';
+  }
+  if (validations.find(message => message.severity === 'ERROR')) {
     return 'variables-editor-row-error';
   }
-  if (messages.find(message => message.severity === 'WARNING')) {
+  if (validations.find(message => message.severity === 'WARNING')) {
     return 'variables-editor-row-warning';
   }
   return '';

--- a/packages/variable-editor/src/components/variables/master/VariablesMasterContent.test.ts
+++ b/packages/variable-editor/src/components/variables/master/VariablesMasterContent.test.ts
@@ -1,0 +1,59 @@
+import type { ValidationMessages } from '@axonivy/variable-editor-protocol';
+import type { Variable } from '../data/variable';
+import { rowHeight, variablesWithValidations } from './VariablesMasterContent';
+
+test('variablesWithValidations', () => {
+  const originalVariables: Array<Variable> = [
+    {
+      name: 'name0',
+      value: '',
+      description: '',
+      metadata: { type: '' },
+      validations: [{ message: 'Existing validation 0' }] as ValidationMessages,
+      children: []
+    },
+    {
+      name: 'name1',
+      value: '',
+      description: '',
+      metadata: { type: '' },
+      validations: [],
+      children: [
+        {
+          name: 'name10',
+          value: '',
+          description: '',
+          metadata: { type: '' },
+          validations: [],
+          children: []
+        },
+        {
+          name: 'name11',
+          value: '',
+          description: '',
+          metadata: { type: '' },
+          validations: [{ message: 'Existing validation 11' }] as ValidationMessages,
+          children: []
+        }
+      ]
+    }
+  ];
+  const validations = [
+    { message: 'Validation 0', path: 'name0' },
+    { message: 'Validation 1a', path: 'name1' },
+    { message: 'Validation 1b', path: 'name1' },
+    { message: 'Validation 10', path: 'name1.name10' }
+  ] as ValidationMessages;
+  const variables = variablesWithValidations(originalVariables, validations);
+  expect(variables[0].validations).toEqual([validations[0]]);
+  expect(variables[1].validations).toEqual([validations[1], validations[2]]);
+  expect(variables[1].children[0].validations).toEqual([validations[3]]);
+  expect(variables[1].children[1].validations).toEqual([]);
+});
+
+test('rowHeight', () => {
+  expect(rowHeight(undefined)).toEqual(36);
+  expect(rowHeight([])).toEqual(36);
+  expect(rowHeight([{}] as ValidationMessages)).toEqual(72);
+  expect(rowHeight([{}, {}, {}] as ValidationMessages)).toEqual(144);
+});


### PR DESCRIPTION
Instantiate the table with a clone of the variables including their validation messages.
Use these validation messages to calculate the height of the virtual rows without the need to use the DOM elements.
Virtualization seems to work a lot better now.
