### PR TITLE
chore: pnpm audit fix transient CVEs

### DIFF
--- a/integrations/standalone/package.json
+++ b/integrations/standalone/package.json
@@ -8,21 +8,21 @@
     "@axonivy/ui-icons": "next-14.0.0",
     "@axonivy/variable-editor": "workspace:~",
     "@axonivy/variable-editor-protocol": "workspace:~",
-    "@tanstack/react-query": "^5.64",
-    "@tanstack/react-query-devtools": "^5.64",
-    "i18next": "^26.0.0",
-    "i18next-browser-languagedetector": "^8.0.4",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-i18next": "^17.0.0"
+    "@tanstack/react-query": "^5.101.0",
+    "@tanstack/react-query-devtools": "^5.101.0",
+    "i18next": "^26.3.1",
+    "i18next-browser-languagedetector": "^8.2.1",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-i18next": "^17.0.8"
   },
   "devDependencies": {
-    "@tailwindcss/vite": "^4.2.2",
-    "@types/react": "^19.0.7",
-    "@types/react-dom": "^19.0.3",
-    "@vitejs/plugin-react": "^6.0.0",
-    "tailwindcss": "^4.1.13",
-    "vite": "^8.0.0"
+    "@tailwindcss/vite": "^4.3.0",
+    "@types/react": "^19.2.16",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.2",
+    "tailwindcss": "^4.3.0",
+    "vite": "^8.0.16"
   },
   "scripts": {
     "clean": "rimraf build",

--- a/package.json
+++ b/package.json
@@ -32,14 +32,14 @@
     "@axonivy/eslint-config": "next-14.0.0",
     "@axonivy/prettier-config": "next-14.0.0",
     "@axonivy/ts-config": "next-14.0.0",
-    "@lerna-lite/cli": "^5.0.0",
-    "@lerna-lite/publish": "^5.0.0",
-    "@lerna-lite/version": "^5.0.0",
-    "@types/node": "^24.0.0",
-    "prettier": "^3.6.2",
-    "rimraf": "^6.0.1",
-    "tailwindcss": "^4.2.2",
-    "typescript": "^6.0.0"
+    "@lerna-lite/cli": "^5.3.0",
+    "@lerna-lite/publish": "^5.3.0",
+    "@lerna-lite/version": "^5.3.0",
+    "@types/node": "^24.13.0",
+    "prettier": "^3.8.3",
+    "rimraf": "^6.1.3",
+    "tailwindcss": "^4.3.0",
+    "typescript": "^6.0.3"
   },
   "prettier": "@axonivy/prettier-config"
 }

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "json-schema-to-typescript": "^15.0.4",
-    "rimraf": "^6.0.1",
-    "typescript": "^6.0.0"
+    "rimraf": "^6.1.3",
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/variable-editor/package.json
+++ b/packages/variable-editor/package.json
@@ -18,8 +18,8 @@
   "main": "lib/editor.js",
   "dependencies": {
     "@axonivy/variable-editor-protocol": "workspace:~",
-    "@tanstack/react-virtual": "^3.12.0",
-    "yaml": "^2.7.0"
+    "@tanstack/react-virtual": "^3.14.2",
+    "yaml": "^2.9.0"
   },
   "peerDependencies": {
     "@axonivy/jsonrpc": "~14.0.0-next",
@@ -35,22 +35,22 @@
     "@axonivy/jsonrpc": "next-14.0.0",
     "@axonivy/ui-components": "next-14.0.0",
     "@axonivy/ui-icons": "next-14.0.0",
-    "@tailwindcss/vite": "^4.2.2",
+    "@tailwindcss/vite": "^4.3.0",
     "@tanstack/react-table": "^8.21.3",
-    "@testing-library/dom": "^10.4.0",
-    "@testing-library/react": "^16.2.0",
-    "@types/react": "^19.0.7",
-    "@vanilla-extract/recipes": "^0.5.5",
-    "@vitejs/plugin-react": "^6.0.0",
-    "i18next-cli": "^1.21.1",
-    "jsdom": "^29.0.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "tailwindcss": "^4.2.2",
-    "typescript": "^6.0.0",
-    "vite": "^8.0.0",
-    "vite-plugin-dts": "^5.0.0",
-    "vitest": "^4.0.0"
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "^19.2.16",
+    "@vanilla-extract/recipes": "^0.5.7",
+    "@vitejs/plugin-react": "^6.0.2",
+    "i18next-cli": "^1.61.0",
+    "jsdom": "^29.1.1",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "tailwindcss": "^4.3.0",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16",
+    "vite-plugin-dts": "^5.0.2",
+    "vitest": "^4.1.8"
   },
   "scripts": {
     "clean": "rimraf lib *.tsbuildinfo",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,28 +18,28 @@ importers:
         specifier: next-14.0.0
         version: 14.0.0-next.1167.343f96e
       '@lerna-lite/cli':
-        specifier: ^5.0.0
+        specifier: ^5.3.0
         version: 5.3.0(@lerna-lite/publish@5.3.0(@types/node@24.13.0)(conventional-commits-filter@5.0.0))(@lerna-lite/version@5.3.0(@lerna-lite/publish@5.3.0(@types/node@24.13.0)(conventional-commits-filter@5.0.0))(@types/node@24.13.0)(conventional-commits-filter@5.0.0))(@types/node@24.13.0)
       '@lerna-lite/publish':
-        specifier: ^5.0.0
+        specifier: ^5.3.0
         version: 5.3.0(@types/node@24.13.0)(conventional-commits-filter@5.0.0)
       '@lerna-lite/version':
-        specifier: ^5.0.0
+        specifier: ^5.3.0
         version: 5.3.0(@lerna-lite/publish@5.3.0(@types/node@24.13.0)(conventional-commits-filter@5.0.0))(@types/node@24.13.0)(conventional-commits-filter@5.0.0)
       '@types/node':
-        specifier: ^24.0.0
+        specifier: ^24.13.0
         version: 24.13.0
       prettier:
-        specifier: ^3.6.2
+        specifier: ^3.8.3
         version: 3.8.3
       rimraf:
-        specifier: ^6.0.1
+        specifier: ^6.1.3
         version: 6.1.3
       tailwindcss:
-        specifier: ^4.2.2
+        specifier: ^4.3.0
         version: 4.3.0
       typescript:
-        specifier: ^6.0.0
+        specifier: ^6.0.3
         version: 6.0.3
 
   integrations/standalone:
@@ -60,44 +60,44 @@ importers:
         specifier: workspace:~
         version: link:../../packages/protocol
       '@tanstack/react-query':
-        specifier: ^5.64
+        specifier: ^5.101.0
         version: 5.101.0(react@19.2.7)
       '@tanstack/react-query-devtools':
-        specifier: ^5.64
+        specifier: ^5.101.0
         version: 5.101.0(@tanstack/react-query@5.101.0(react@19.2.7))(react@19.2.7)
       i18next:
-        specifier: ^26.0.0
+        specifier: ^26.3.1
         version: 26.3.1(typescript@6.0.3)
       i18next-browser-languagedetector:
-        specifier: ^8.0.4
+        specifier: ^8.2.1
         version: 8.2.1
       react:
-        specifier: ^19.0.0
+        specifier: ^19.2.7
         version: 19.2.7
       react-dom:
-        specifier: ^19.0.0
+        specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
       react-i18next:
-        specifier: ^17.0.0
+        specifier: ^17.0.8
         version: 17.0.8(i18next@26.3.1(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
     devDependencies:
       '@tailwindcss/vite':
-        specifier: ^4.2.2
+        specifier: ^4.3.0
         version: 4.3.0(vite@8.0.16(@types/node@24.13.0)(jiti@2.7.0)(yaml@2.9.0))
       '@types/react':
-        specifier: ^19.0.7
+        specifier: ^19.2.16
         version: 19.2.16
       '@types/react-dom':
-        specifier: ^19.0.3
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.16)
       '@vitejs/plugin-react':
-        specifier: ^6.0.0
+        specifier: ^6.0.2
         version: 6.0.2(vite@8.0.16(@types/node@24.13.0)(jiti@2.7.0)(yaml@2.9.0))
       tailwindcss:
-        specifier: ^4.1.13
+        specifier: ^4.3.0
         version: 4.3.0
       vite:
-        specifier: ^8.0.0
+        specifier: ^8.0.16
         version: 8.0.16(@types/node@24.13.0)(jiti@2.7.0)(yaml@2.9.0)
 
   packages/protocol:
@@ -106,10 +106,10 @@ importers:
         specifier: ^15.0.4
         version: 15.0.4
       rimraf:
-        specifier: ^6.0.1
+        specifier: ^6.1.3
         version: 6.1.3
       typescript:
-        specifier: ^6.0.0
+        specifier: ^6.0.3
         version: 6.0.3
 
   packages/variable-editor:
@@ -124,7 +124,7 @@ importers:
         specifier: ^5.64
         version: 5.101.0(@tanstack/react-query@5.101.0(react@19.2.7))(react@19.2.7)
       '@tanstack/react-virtual':
-        specifier: ^3.12.0
+        specifier: ^3.14.2
         version: 3.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       i18next:
         specifier: ^25.0.0 || ^26.0.0
@@ -133,7 +133,7 @@ importers:
         specifier: ^16.0.0 || ^17.0.0
         version: 17.0.8(i18next@26.3.1(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       yaml:
-        specifier: ^2.7.0
+        specifier: ^2.9.0
         version: 2.9.0
     devDependencies:
       '@axonivy/jsonrpc':
@@ -146,52 +146,52 @@ importers:
         specifier: next-14.0.0
         version: 14.0.0-next.1167.343f96e
       '@tailwindcss/vite':
-        specifier: ^4.2.2
+        specifier: ^4.3.0
         version: 4.3.0(vite@8.0.16(@types/node@24.13.0)(jiti@2.7.0)(yaml@2.9.0))
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@testing-library/dom':
-        specifier: ^10.4.0
+        specifier: ^10.4.1
         version: 10.4.1
       '@testing-library/react':
-        specifier: ^16.2.0
+        specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react':
-        specifier: ^19.0.7
+        specifier: ^19.2.16
         version: 19.2.16
       '@vanilla-extract/recipes':
-        specifier: ^0.5.5
+        specifier: ^0.5.7
         version: 0.5.7(@vanilla-extract/css@1.20.1)
       '@vitejs/plugin-react':
-        specifier: ^6.0.0
+        specifier: ^6.0.2
         version: 6.0.2(vite@8.0.16(@types/node@24.13.0)(jiti@2.7.0)(yaml@2.9.0))
       i18next-cli:
-        specifier: ^1.21.1
+        specifier: ^1.61.0
         version: 1.61.0(@swc/helpers@0.5.19)(@types/node@24.13.0)(react-dom@19.2.7(react@19.2.7))(typescript@6.0.3)
       jsdom:
-        specifier: ^29.0.0
+        specifier: ^29.1.1
         version: 29.1.1
       react:
-        specifier: ^19.0.0
+        specifier: ^19.2.7
         version: 19.2.7
       react-dom:
-        specifier: ^19.0.0
+        specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
       tailwindcss:
-        specifier: ^4.2.2
+        specifier: ^4.3.0
         version: 4.3.0
       typescript:
-        specifier: ^6.0.0
+        specifier: ^6.0.3
         version: 6.0.3
       vite:
-        specifier: ^8.0.0
+        specifier: ^8.0.16
         version: 8.0.16(@types/node@24.13.0)(jiti@2.7.0)(yaml@2.9.0)
       vite-plugin-dts:
-        specifier: ^5.0.0
+        specifier: ^5.0.2
         version: 5.0.2(rolldown@1.0.3)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.0)(jiti@2.7.0)(yaml@2.9.0))
       vitest:
-        specifier: ^4.0.0
+        specifier: ^4.1.8
         version: 4.1.8(@types/node@24.13.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.13.0)(jiti@2.7.0)(yaml@2.9.0))
 
   playwright:
@@ -2698,8 +2698,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -3871,7 +3871,7 @@ snapshots:
     dependencies:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -6552,7 +6552,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 
@@ -6592,7 +6592,7 @@ snapshots:
       '@types/json-schema': 7.0.15
       '@types/lodash': 4.17.24
       is-glob: 4.0.3
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       lodash: 4.18.1
       minimist: 1.2.8
       prettier: 3.8.3


### PR DESCRIPTION
## Summary
- Baseline audit status: 1 CVE
- Final audit status: 0 CVE
- Files changed: pnpm-lock.yaml (and package.json files with dep bumps)